### PR TITLE
feature contract v1 registry validation and provenance wiring

### DIFF
--- a/docs/spec/feature_contract_v1.md
+++ b/docs/spec/feature_contract_v1.md
@@ -1,0 +1,346 @@
+# Feature Contract v1
+
+## Purpose
+
+この文書は、`train / eval / backtest parity` のために、feature の入力契約を v1 として固定するための spec です。
+
+実装面では、registry と config-load validation が repo 内に追加されており、`dataset_feature_set` と
+`model_feature_columns` の境界は code path でもこの v1 に従って検証されます。
+
+artifact provenance も v1 に紐づけて保存され、少なくとも dataset / prediction / backtest / live proxy の
+一部 artifact では `feature_contract_version` と feature interpretation を追跡できます。
+
+今回の目的は model 改善ではなく、比較基盤の固定です。したがって本書は、
+
+- feature の source
+- feature の availability timing
+- `train / eval / backtest` での利用可否
+- leakage prohibition
+- missing handling
+
+を feature 単位で明文化します。
+
+## Scope
+
+v1 の対象は、現在 repo で dataset build と model/backtest rolling retrain に現れている horse-level feature です。
+
+対象外:
+
+- BET rule の変更
+- model family の改善
+- pair/wide research 固有の score engineering
+- post-race outcome や payout を feature 化すること
+
+## Contract Layers
+
+feature parity は v1 では次の 2 層で定義します。
+
+1. `dataset_feature_set`
+   - dataset builder が upstream staging からどの feature 列を materialize してよいかを決める
+2. `model_feature_columns`
+   - train / rolling retrain / live proxy がどの列をどの順序で数値入力として使うかを決める
+
+v1 では `model_feature_columns` は必ず dataset schema 上の feature 列の subset でなければならず、
+列順も train / rolling retrain / live proxy で一致しなければならない。
+
+## Parity Definitions
+
+### Train
+
+- dataset parquet の feature 列をそのまま学習入力として使う
+- `feature_columns` と `feature_transforms` は順序まで含めて契約の一部
+
+### Eval
+
+- v1 の `eval` は model 予測評価と rolling window 評価を指す
+- static eval は `predictions.csv` を読むため direct feature input は持たない
+- ただし predictions の provenance は同一 `dataset_feature_set + feature_columns + feature_transforms` に固定されるべき
+
+### Backtest
+
+- static backtest は `predictions.csv` 消費なので direct feature input は持たない
+- `rolling_retrain` backtest は dataset を再読込して再学習するため、train と同じ feature contract を守る必要がある
+
+### Live Proxy
+
+- live proxy は parity 補助であり mainline parity source ではない
+- 現在は `place_basis_odds` のみ alias/proxy を明示して扱う
+- runbook にある通り、live proxy 出力を mainline backtest と横並び比較してはいけない
+
+## Global Rules
+
+### Feature Eligibility
+
+- pre-race only feature だけを model input に使ってよい
+- post-race outcome / payout / result confirmation列は feature にしてはいけない
+- upstream raw field と project-derived feature を区別して記録する
+- market-derived feature は market proxy であることを明示する
+
+### Timing Rules
+
+- feature の `availability timing` は「その値を正当に意思決定に使える最も早い時点」で判定する
+- ただし v1 では `historical carrier timing` も別途意識する
+- 今回の整理では `win_odds` だけを先行して pre-race carrier contract へ移し、`popularity` は未確認のため `legacy_sed_only` として残す
+
+### Leakage Prohibition
+
+- `finish_position`, `result_date`, `win_payout`, `place_payout_*` を feature に流してはいけない
+- target source column は dataset schema に出してはいけない
+- 同一 `race_key` は split を跨いではいけない
+- `train / valid / test` は `race_date` 時系列でのみ分ける
+- derived feature も input source に post-race 列を含んではいけない
+- live input には `target_value`, `split`, `pred_probability`, `finish_position`, `payout` など leakage 列を含めてはいけない
+
+### Missing Handling
+
+- v1 では missing を「暗黙補完しない」が原則
+- upstream null / parse failure / zero-division は `NULL` のまま dataset に出る
+- model 側は現状、数値に `float(...)` 変換できる前提なので、実運用上は null を含む feature set をそのまま train しない
+- missing strategy を導入する場合は feature contract v2 で明示する
+
+## Feature Inventory
+
+| feature | class | source | availability timing | train | eval | backtest | leakage risk | missing handling | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `win_odds` | upstream raw, market-derived | `jrdb_win_market_snapshot_v1.win_odds` | pre-race | allow | allow via provenance | allow | low-to-medium | carrier missing -> `NULL` | current carrier row is project-owned and populated from `OZ.win_basis_odds`; provenance carrier identity is `win_market_snapshot_v1` |
+| `popularity` | upstream raw, market-derived | `SED.popularity` | pre-race semantic, post-race carrier in current offline build | allow | allow via provenance | allow | medium | parse failure -> `NULL` | ordinal rank。pre-race carrier is not yet confirmed; provenance carrier identity is `legacy_sed_only` |
+| `place_basis_odds` | upstream raw, market-derived | `OZ.place_basis_odds` | pre-race | allow | allow via provenance | allow | low | parse failure -> `NULL` | live proxy では `place_basis_odds_proxy` alias を使う |
+| `headcount` | upstream raw, market-derived support field | `OZ.headcount` | pre-race | allow | allow via provenance | allow | low | parse failure -> `NULL` | provisional semantics。place market array header 由来 |
+| `distance_m` | upstream raw | `BAC.distance_m` | pre-race | allow | allow via provenance | allow | low | upstream null -> `NULL` | model parity では numeric feature としてのみ使用可 |
+| `race_name` | upstream raw text | `BAC.race_name` | pre-race | deny in current parity path | not used directly | deny in rolling parity | low | upstream null -> `NULL` | dataset には出るが current model contract には入れない |
+| `workout_weekday` | upstream raw text | `CHA.workout_weekday` | pre-race | deny in current parity path | not used directly | deny in rolling parity | low | upstream null -> `NULL` | raw text のままでは model input にしない |
+| `workout_date` | upstream raw date | `CHA.workout_date` | pre-race | deny in current parity path | not used directly | deny in rolling parity | low | upstream null -> `NULL` | raw date のままでは model input にしない |
+| `workout_gap_days` | project-derived | `BAC.race_date - CHA.workout_date` | pre-race | allow | allow via provenance | allow | low | source null -> `NULL` | race date 基準の derived feature |
+| `workout_weekday_code` | project-derived | mapping from `CHA.workout_weekday` | pre-race | allow | allow via provenance | allow | low | unmapped/null -> `NULL` | `月..日 -> 0..6` |
+| `place_slot_count` | project-derived | derived from `OZ.headcount` | pre-race | allow | allow via provenance | allow | low | `headcount NULL` -> `NULL` | `<=7 => 2 else 3` |
+| `log_place_minus_log_win` | project-derived, market-derived | `LN(place_basis_odds) - LN(win_odds)` | pre-race semantic | allow | allow via provenance | allow | medium | invalid log input -> `NULL` | current source mixes `OZ` + `SED` carrier |
+| `implied_place_prob` | project-derived, market-derived | `1 / place_basis_odds` | pre-race | allow | allow via provenance | allow | low | zero/null -> `NULL` | current transform は `identity` のみ |
+| `implied_win_prob` | project-derived, market-derived | `1 / win_odds` | pre-race semantic | allow | allow via provenance | allow | medium | zero/null -> `NULL` | current source carrier は `SED` |
+| `implied_place_prob_minus_implied_win_prob` | project-derived, market-derived | `implied_place_prob - implied_win_prob` | pre-race semantic | allow | allow via provenance | allow | medium | source null -> `NULL` | dual-market relation feature |
+| `place_to_win_ratio` | project-derived, market-derived | `place_basis_odds / win_odds` | pre-race semantic | allow | allow via provenance | allow | medium | zero/null -> `NULL` | dual-market relation feature |
+
+## Feature Classes
+
+### Upstream Raw Pre-Race Fields
+
+- `BAC.distance_m`
+- `BAC.race_name`
+- `CHA.workout_weekday`
+- `CHA.workout_date`
+- `SED.popularity`
+- `jrdb_win_market_snapshot_v1.win_odds`
+- `OZ.place_basis_odds`
+- `OZ.headcount`
+
+### Project-Derived Pre-Race Features
+
+- `workout_gap_days`
+- `workout_weekday_code`
+- `place_slot_count`
+- `log_place_minus_log_win`
+- `implied_place_prob`
+- `implied_win_prob`
+- `implied_place_prob_minus_implied_win_prob`
+- `place_to_win_ratio`
+
+### Pre-Race Only vs Post-Race
+
+pre-race only:
+
+- 上表の feature はすべて semantic には pre-race only として扱う
+
+post-race or result-only:
+
+- `finish_position`
+- `result_date`
+- `win_horse_number`
+- `win_payout`
+- `place_horse_number_*`
+- `place_payout_*`
+- any label/target column such as `target_value`
+
+これらは feature contract v1 では全面禁止。
+
+### Market-Derived
+
+- `win_odds`
+- `popularity`
+- `place_basis_odds`
+- `headcount`
+- `place_slot_count`
+- `log_place_minus_log_win`
+- `implied_place_prob`
+- `implied_win_prob`
+- `implied_place_prob_minus_implied_win_prob`
+- `place_to_win_ratio`
+
+### Non-Market Structural / Workout
+
+- `distance_m`
+- `race_name`
+- `workout_weekday`
+- `workout_date`
+- `workout_gap_days`
+- `workout_weekday_code`
+
+## Current Parity Status
+
+### Fully Parity-Safe In Current Numeric Model Path
+
+- `win_odds`
+- `popularity`
+- `place_basis_odds`
+- `headcount`
+- `distance_m`
+- `workout_gap_days`
+- `workout_weekday_code`
+- `place_slot_count`
+- `log_place_minus_log_win`
+- `implied_place_prob`
+- `implied_win_prob`
+- `implied_place_prob_minus_implied_win_prob`
+- `place_to_win_ratio`
+
+意味:
+
+- dataset build で列化されている
+- `validate_model_feature_spec(...)` が train/rolling_retrain 入力として受理する
+- backtest rolling retrain でも同じ列順契約を持てる
+
+### Dataset-Only Or Non-Parity-Safe In Current Path
+
+- `race_name`
+- `workout_weekday`
+- `workout_date`
+
+意味:
+
+- dataset には出せる
+- ただし current model/backtest parity path の numeric input 契約には入っていない
+- これらを使う場合は encoding と missing policy を先に固定する必要がある
+
+## Approved Feature Sets In v1
+
+`dataset_feature_set` と `model_feature_columns` の対応は、少なくとも以下の範囲に固定する。
+
+| dataset_feature_set | intended model_feature_columns |
+| --- | --- |
+| `odds_only` | `win_odds` |
+| `odds_only` + `include_popularity=true` | `win_odds`, `popularity` |
+| `win_market_only` | `win_odds`, `popularity` |
+| `current_win_market` | `win_odds`, `popularity` |
+| `place_market_only` | `place_basis_odds` |
+| `place_market_plus_popularity` | `place_basis_odds`, `popularity` |
+| `dual_market` | `win_odds`, `place_basis_odds`, `popularity` |
+| `dual_market_for_win` | `win_odds`, `place_basis_odds`, `popularity` |
+| `dual_market_plus_headcount` | `win_odds`, `place_basis_odds`, `popularity`, `headcount` |
+| `dual_market_plus_headcount_place_slots` | `win_odds`, `place_basis_odds`, `popularity`, `headcount`, `place_slot_count` |
+| `dual_market_plus_headcount_place_slots_distance` | `win_odds`, `place_basis_odds`, `popularity`, `headcount`, `place_slot_count`, `distance_m` |
+| `dual_market_plus_log_diff` | `win_odds`, `place_basis_odds`, `popularity`, `log_place_minus_log_win` |
+| `dual_market_plus_implied_probs` | `win_odds`, `place_basis_odds`, `popularity`, `implied_place_prob`, `implied_win_prob` |
+| `dual_market_plus_prob_diff` | `win_odds`, `place_basis_odds`, `popularity`, `implied_place_prob_minus_implied_win_prob` |
+| `dual_market_plus_ratio` | `win_odds`, `place_basis_odds`, `popularity`, `place_to_win_ratio` |
+| `market_plus_workout_minimal` | `win_odds`, `popularity`, `workout_gap_days`, `workout_weekday_code` |
+
+`minimal` は dataset exploration 用に残すが、current parity-safe numeric model path の feature contract には含めない。
+
+## Timestamp And Timing Assumptions
+
+- split 判定は `race_date` 基準で行う
+- `workout_gap_days` は `race_date - workout_date` で算出する
+- `place_slot_count` は race day 前に既知の `headcount` を前提にする
+- `win_odds` / `popularity` / `place_basis_odds` は race start 前に観測される market snapshot を意味する
+- ただし historical build では `win_odds` / `popularity` は `SED` result carrier を経由しており、strict source parity は未達
+
+## Source Confirmation Freeze Status
+
+判定日時:
+
+- 2026-04-19
+
+判定:
+
+- `popularity` source status: `unresolved`
+- `win_odds` source status: `confirmed_pre_race_proxy_exists_but_not_adopted_as_sed_replacement`
+- carrier relationship: `unresolved`
+
+confirmed facts:
+
+- JRDB `SED` official spec では `確定単勝オッズ` と `確定単勝人気順位` が同一 result-side file に存在する
+- repo の `jrdb_sed_staging` も `win_odds` と `popularity` をこの carrier から取り込んでいる
+- repo の `jrdb_oz_staging` / OZ parser は pre-race odds array を `win_basis_odds` / `place_basis_odds` に展開している
+- 現在の repo 内根拠では、OZ 側に `popularity` を upstream-formalized field として確認できていない
+
+freeze decision:
+
+- `jrdb_win_market_snapshot_v1` は `win_odds + popularity` の single contract としてはまだ凍結しない
+- `OZ.win_basis_odds` は legacy `SED.win_odds` の drop-in replacement としては採用しない
+  - carrier migration evaluation の recommendation は `rollback`
+  - discrepancy audit の recommendation は `hold_and_deeper_source_audit`
+  - 最有力な理由は broad join collapse ではなく、semantic mismatch に timing mismatch 成分が重なっている可能性が高いこと
+- 実装前の contract 表現は次で保留する
+  - `win_odds`: pre-race market proxy candidate は存在するが、mainline replacement としては未採用
+  - `popularity`: true upstream pre-race carrier 未確認
+  - `jrdb_win_market_snapshot_v1`: `popularity` は provisional/optional candidate として扱い、required column にしない
+
+blocked reason:
+
+- `popularity` を `win_odds` と同一の pre-race carrier で取得できる根拠が repo 内では未確認
+- `OZ.win_basis_odds` は `SED.win_odds` と比べて drift が極めて大きく、source audit でも broad join collapse より semantic/timing mismatch が有力
+
+## Leakage Rules By Feature Class
+
+### Rule A: Result-Derived Inputs Forbidden
+
+禁止:
+
+- `finish_position`
+- `result_date`
+- `win_payout`
+- `place_payout_*`
+- any outcome-derived aggregation
+
+### Rule B: Semantic Pre-Race But Post-Race Carrier Requires Care
+
+対象:
+
+- `win_odds`
+- `popularity`
+- `implied_win_prob`
+- `log_place_minus_log_win`
+- `implied_place_prob_minus_implied_win_prob`
+- `place_to_win_ratio`
+
+ルール:
+
+- v1 では offline comparison には使ってよい
+- ただし `SED` carrier を理由に live parity completed と見なしてはいけない
+- live 比較では必ず proxy / alias / caveat を残す
+
+### Rule C: Derived Feature Must Inherit Strictest Source Rule
+
+- derived feature の leakage risk は source の最大値を継承する
+- `OZ` と `SED` を混ぜる derived feature は `SED` 側の carrier risk を引き継ぐ
+
+### Rule D: Config Must Not Invent New Features
+
+- `feature_columns` に指定できるのは dataset schema 上の既存列だけ
+- docs に未登録の feature を config だけで追加してはいけない
+- 新 feature は source / timing / missing / leakage を先に spec 化する
+
+## Follow-Up TODO
+
+1. feature registry をコード化し、`dataset_feature_set` と `feature_columns` の整合を config load 時に検証する
+2. low-correlation race tail を対象に raw upstream line を監査し、`OZ.win_basis_odds` の snapshot semantics を狭く確認する
+3. `popularity` の true upstream pre-race carrier を確認する
+4. dataset artifact に `feature_contract_version` と feature provenance manifest を同梱する
+5. `minimal` feature set の text/date feature を parity path に入れるか、exploration-only として固定するかを決める
+6. missing/null policy を feature ごとに明文化し、train 前 validation に落とし込む
+7. live proxy contract を feature registry 参照型にして、`place_basis_odds_proxy` 以外の alias も管理可能にする
+
+## Non-Goals For This Issue
+
+- feature 自体の追加
+- BET logic の変更
+- model 改善実装
+- large-scale training pipeline refactor

--- a/scripts/live_inference_score.py
+++ b/scripts/live_inference_score.py
@@ -13,6 +13,8 @@ from pathlib import Path
 import duckdb
 import numpy as np
 
+from horse_bet_lab.features.provenance import build_feature_provenance_payload
+from horse_bet_lab.features.registry import validate_model_feature_columns
 from horse_bet_lab.model.service import (
     apply_feature_transforms,
     fit_model,
@@ -92,6 +94,11 @@ def load_config(path: Path) -> LiveInferenceConfig:
     payload = tomllib.loads(path.read_text(encoding="utf-8"))
     run = payload["live_inference"]
     reference = run["reference_model"]
+    feature_columns = tuple(str(value) for value in reference["feature_columns"])
+    validate_model_feature_columns(
+        feature_columns,
+        context=f"live_inference.reference_model feature_columns in {path}",
+    )
     return LiveInferenceConfig(
         name=str(run["name"]),
         race_name=str(run["race_name"]),
@@ -111,7 +118,7 @@ def load_config(path: Path) -> LiveInferenceConfig:
                 else None
             ),
             model_name=str(reference["model_name"]),
-            feature_columns=tuple(str(value) for value in reference["feature_columns"]),
+            feature_columns=feature_columns,
             feature_transforms=tuple(str(value) for value in reference["feature_transforms"]),
             target_column=str(reference.get("target_column", "target_value")),
             split_column=str(reference.get("split_column", "split")),
@@ -381,6 +388,22 @@ def write_manifest(config: LiveInferenceConfig, path: Path) -> None:
         "feature_list": list(config.reference_model.feature_columns),
         "proxy_rule": config.proxy_rule,
         "caveat": list(config.caveat),
+        "provenance": build_feature_provenance_payload(
+            artifact_kind="live_proxy_manifest_json",
+            generated_by="scripts.live_inference_score.write_manifest",
+            config_identifier=config.name,
+            model_feature_columns=config.reference_model.feature_columns,
+            artifact_path=str(path),
+            extra={
+                "dataset_path": str(config.reference_model.dataset_path),
+                "historical_duckdb_path": (
+                    str(config.reference_model.historical_duckdb_path)
+                    if config.reference_model.historical_duckdb_path is not None
+                    else None
+                ),
+                "training_splits": list(config.reference_model.training_splits),
+            },
+        ),
     }
     path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False), encoding="utf-8")
 
@@ -504,7 +527,6 @@ def write_proxy_gap_diagnostic(
 
 def sha256_digest(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
-
 
 def main() -> None:
     args = build_parser().parse_args()

--- a/src/horse_bet_lab/config.py
+++ b/src/horse_bet_lab/config.py
@@ -5,6 +5,12 @@ from dataclasses import dataclass, field
 from datetime import date
 from pathlib import Path
 
+from horse_bet_lab.features.registry import (
+    validate_dataset_feature_set,
+    validate_model_feature_columns,
+    validate_model_feature_columns_for_dataset_feature_set,
+)
+
 
 @dataclass(frozen=True)
 class ExperimentConfig:
@@ -546,14 +552,17 @@ def load_dataset_build_config(path: Path) -> DatasetBuildConfig:
     dataset = raw_config["dataset"]
     train_end_date = dataset.get("train_end_date")
     valid_end_date = dataset.get("valid_end_date")
+    feature_set = str(dataset.get("feature_set", "minimal"))
+    include_popularity = bool(dataset.get("include_popularity", False))
+    validate_dataset_feature_set(feature_set, include_popularity=include_popularity)
     return DatasetBuildConfig(
         name=dataset["name"],
         start_date=date.fromisoformat(dataset["start_date"]),
         end_date=date.fromisoformat(dataset["end_date"]),
         train_end_date=date.fromisoformat(train_end_date) if train_end_date is not None else None,
         valid_end_date=date.fromisoformat(valid_end_date) if valid_end_date is not None else None,
-        feature_set=dataset.get("feature_set", "minimal"),
-        include_popularity=bool(dataset.get("include_popularity", False)),
+        feature_set=feature_set,
+        include_popularity=include_popularity,
         target_name=dataset["target_name"],
         duckdb_path=Path(dataset["duckdb_path"]),
         output_path=Path(dataset["output_path"]),
@@ -568,6 +577,10 @@ def load_model_train_config(path: Path) -> ModelTrainConfig:
     feature_columns = tuple(training["feature_columns"])
     feature_transforms = tuple(
         training.get("feature_transforms", ["identity"] * len(feature_columns)),
+    )
+    validate_model_feature_columns(
+        feature_columns,
+        context=f"training feature_columns in {path}",
     )
     return ModelTrainConfig(
         name=training["name"],
@@ -601,6 +614,16 @@ def load_market_feature_comparison_config(path: Path) -> MarketFeatureComparison
         )
         for feature_set in comparison["feature_sets"]
     )
+    for feature_set in feature_sets:
+        validate_model_feature_columns_for_dataset_feature_set(
+            dataset_feature_set=feature_set.dataset_feature_set,
+            include_popularity=feature_set.include_popularity,
+            feature_columns=feature_set.feature_columns,
+            context=(
+                f"comparison feature_columns for feature_set {feature_set.name!r} "
+                f"in {path}"
+            ),
+        )
     return MarketFeatureComparisonConfig(
         name=str(comparison["name"]),
         duckdb_path=Path(comparison["duckdb_path"]),
@@ -1436,6 +1459,11 @@ def load_place_backtest_config(path: Path) -> PlaceBacktestConfig:
         if rolling_retrain is not None
         else ()
     )
+    if rolling_retrain is not None and rolling_feature_columns:
+        validate_model_feature_columns(
+            rolling_feature_columns,
+            context=f"rolling_retrain feature_columns in {path}",
+        )
     return PlaceBacktestConfig(
         name=backtest["name"],
         predictions_path=Path(backtest["predictions_path"]),
@@ -1652,7 +1680,6 @@ def load_wide_family_selection_config(path: Path) -> WideFamilySelectionConfig:
             float(analysis["v6_partner_weight"]) if "v6_partner_weight" in analysis else None
         ),
     )
-
 
 def parse_model_params(raw_params: object) -> dict[str, object]:
     if raw_params is None:

--- a/src/horse_bet_lab/dataset/service.py
+++ b/src/horse_bet_lab/dataset/service.py
@@ -11,74 +11,17 @@ from horse_bet_lab.dataset.targets import (
     result_target_filter_sql,
     target_definition,
 )
+from horse_bet_lab.features.registry import dataset_feature_columns
+from horse_bet_lab.features.provenance import (
+    build_feature_provenance_payload,
+    dataset_model_feature_columns,
+    write_feature_provenance_sidecar,
+)
 from horse_bet_lab.ingest.specs import CONFIRMED, SUPPORTED_FILE_SPECS, dataset_allowlist
 
 METADATA_COLUMNS = ("race_key", "horse_number", "race_date", "split", "target_name")
 TARGET_COLUMNS = ("target_value",)
 TARGET_SOURCE_COLUMNS = ("finish_position", "result_date")
-
-FEATURE_SET_COLUMNS = {
-    "minimal": ("distance_m", "race_name", "workout_weekday", "workout_date"),
-    "odds_only": ("win_odds",),
-    "win_market_only": ("win_odds", "popularity"),
-    "current_win_market": ("win_odds", "popularity"),
-    "place_market_only": ("place_basis_odds",),
-    "place_market_plus_popularity": ("place_basis_odds", "popularity"),
-    "dual_market": ("win_odds", "place_basis_odds", "popularity"),
-    "dual_market_for_win": ("win_odds", "place_basis_odds", "popularity"),
-    "dual_market_plus_headcount": (
-        "win_odds",
-        "place_basis_odds",
-        "popularity",
-        "headcount",
-    ),
-    "dual_market_plus_headcount_place_slots": (
-        "win_odds",
-        "place_basis_odds",
-        "popularity",
-        "headcount",
-        "place_slot_count",
-    ),
-    "dual_market_plus_headcount_place_slots_distance": (
-        "win_odds",
-        "place_basis_odds",
-        "popularity",
-        "headcount",
-        "place_slot_count",
-        "distance_m",
-    ),
-    "dual_market_plus_log_diff": (
-        "win_odds",
-        "place_basis_odds",
-        "popularity",
-        "log_place_minus_log_win",
-    ),
-    "dual_market_plus_implied_probs": (
-        "win_odds",
-        "place_basis_odds",
-        "popularity",
-        "implied_place_prob",
-        "implied_win_prob",
-    ),
-    "dual_market_plus_prob_diff": (
-        "win_odds",
-        "place_basis_odds",
-        "popularity",
-        "implied_place_prob_minus_implied_win_prob",
-    ),
-    "dual_market_plus_ratio": (
-        "win_odds",
-        "place_basis_odds",
-        "popularity",
-        "place_to_win_ratio",
-    ),
-    "market_plus_workout_minimal": (
-        "win_odds",
-        "popularity",
-        "workout_gap_days",
-        "workout_weekday_code",
-    ),
-}
 
 
 @dataclass(frozen=True)
@@ -102,6 +45,39 @@ def build_horse_dataset(config: DatasetBuildConfig) -> DatasetBuildSummary:
         if row_count is None:
             raise RuntimeError("failed to count dataset rows")
         validate_built_dataset(connection, config)
+        write_feature_provenance_sidecar(
+            config.output_path,
+            build_feature_provenance_payload(
+                artifact_kind="dataset_parquet",
+                generated_by="horse_bet_lab.dataset.service.build_horse_dataset",
+                config_identifier=config.name,
+                dataset_feature_set=config.feature_set,
+                include_popularity=config.include_popularity,
+                model_feature_columns=dataset_model_feature_columns(
+                    config.feature_set,
+                    include_popularity=config.include_popularity,
+                ),
+                artifact_path=str(config.output_path),
+                extra={
+                    "duckdb_path": str(config.duckdb_path),
+                    "target_name": config.target_name,
+                    "date_range": {
+                        "start_date": config.start_date.isoformat(),
+                        "end_date": config.end_date.isoformat(),
+                        "train_end_date": (
+                            config.train_end_date.isoformat()
+                            if config.train_end_date is not None
+                            else None
+                        ),
+                        "valid_end_date": (
+                            config.valid_end_date.isoformat()
+                            if config.valid_end_date is not None
+                            else None
+                        ),
+                    },
+                },
+            ),
+        )
         return DatasetBuildSummary(output_path=config.output_path, row_count=int(row_count[0]))
     finally:
         connection.close()
@@ -129,6 +105,12 @@ def dataset_query(config: DatasetBuildConfig) -> str:
         return market_feature_dataset_query(config)
 
     definition = target_definition(config.target_name)
+    extra_joins = ()
+    if config.feature_set == "market_plus_workout_minimal":
+        extra_joins = (
+            "LEFT JOIN jrdb_win_market_snapshot_v1 w "
+            "ON c.race_key = w.race_key AND c.horse_number = w.horse_number",
+        )
     select_parts = [
         "c.race_key AS race_key",
         "c.horse_number AS horse_number",
@@ -146,6 +128,7 @@ def dataset_query(config: DatasetBuildConfig) -> str:
         INNER JOIN jrdb_bac_staging b
             ON c.race_key = b.race_key
         {definition.join_sql}
+        {" ".join(extra_joins)}
         WHERE b.race_date BETWEEN DATE '{config.start_date.isoformat()}'
             AND DATE '{config.end_date.isoformat()}'
             AND {definition.filter_sql}
@@ -159,16 +142,16 @@ def odds_only_dataset_query(config: DatasetBuildConfig) -> str:
             "odds_only feature_set currently supports target_name='is_place' or 'is_win' only",
         )
 
-    sed_columns = selected_columns("SED", allowed_statuses=(CONFIRMED, "provisional"))
     select_parts = [
         "r.race_key AS race_key",
         "r.horse_number AS horse_number",
         "r.result_date AS race_date",
         f"{split_case_sql(config, table_alias='r', date_column='result_date')} AS split",
         f"'{config.target_name}' AS target_name",
-        f"TRY_CAST(r.{sed_columns['win_odds']} AS DOUBLE) AS win_odds",
+        "w.win_odds AS win_odds",
     ]
     if config.include_popularity:
+        sed_columns = selected_columns("SED", allowed_statuses=(CONFIRMED, "provisional"))
         select_parts.append(f"r.{sed_columns['popularity']} AS popularity")
     select_parts.append(
         f"{result_target_expression_sql(config.target_name, table_alias='r')} AS target_value",
@@ -178,6 +161,9 @@ def odds_only_dataset_query(config: DatasetBuildConfig) -> str:
         SELECT
             {", ".join(select_parts)}
         FROM jrdb_sed_staging r
+        LEFT JOIN jrdb_win_market_snapshot_v1 w
+            ON r.race_key = w.race_key
+            AND r.horse_number = w.horse_number
         WHERE r.result_date BETWEEN DATE '{config.start_date.isoformat()}'
             AND DATE '{config.end_date.isoformat()}'
             AND {result_target_filter_sql(config.target_name, table_alias='r')}
@@ -199,10 +185,13 @@ def win_market_only_dataset_query(config: DatasetBuildConfig) -> str:
             r.result_date AS race_date,
             {split_case_sql(config, table_alias='r', date_column='result_date')} AS split,
             '{config.target_name}' AS target_name,
-            TRY_CAST(r.{sed_columns['win_odds']} AS DOUBLE) AS win_odds,
+            w.win_odds AS win_odds,
             r.{sed_columns['popularity']} AS popularity,
             {result_target_expression_sql(config.target_name, table_alias='r')} AS target_value
         FROM jrdb_sed_staging r
+        LEFT JOIN jrdb_win_market_snapshot_v1 w
+            ON r.race_key = w.race_key
+            AND r.horse_number = w.horse_number
         WHERE r.result_date BETWEEN DATE '{config.start_date.isoformat()}'
             AND DATE '{config.end_date.isoformat()}'
             AND {result_target_filter_sql(config.target_name, table_alias='r')}
@@ -232,6 +221,9 @@ def market_feature_dataset_query(config: DatasetBuildConfig) -> str:
         SELECT
             {", ".join(select_parts)}
         FROM jrdb_sed_staging r
+        LEFT JOIN jrdb_win_market_snapshot_v1 w
+            ON r.race_key = w.race_key
+            AND r.horse_number = w.horse_number
         INNER JOIN jrdb_oz_staging o
             ON r.race_key = o.race_key
             AND r.horse_number = o.horse_number
@@ -257,9 +249,9 @@ def feature_select_parts(config: DatasetBuildConfig) -> tuple[str, ...]:
             raise ValueError(
                 "odds_only feature_set currently supports target_name='is_place' or 'is_win' only",
             )
-        sed_columns = selected_columns("SED", allowed_statuses=(CONFIRMED, "provisional"))
-        select_parts = [f"TRY_CAST(r.{sed_columns['win_odds']} AS DOUBLE) AS win_odds"]
+        select_parts = ["w.win_odds AS win_odds"]
         if config.include_popularity:
+            sed_columns = selected_columns("SED", allowed_statuses=(CONFIRMED, "provisional"))
             select_parts.append(f"r.{sed_columns['popularity']} AS popularity")
         return tuple(select_parts)
     if config.feature_set == "win_market_only":
@@ -269,7 +261,7 @@ def feature_select_parts(config: DatasetBuildConfig) -> tuple[str, ...]:
             )
         sed_columns = selected_columns("SED", allowed_statuses=(CONFIRMED, "provisional"))
         return (
-            f"TRY_CAST(r.{sed_columns['win_odds']} AS DOUBLE) AS win_odds",
+            "w.win_odds AS win_odds",
             f"r.{sed_columns['popularity']} AS popularity",
         )
     if config.feature_set in {
@@ -297,7 +289,7 @@ def feature_select_parts(config: DatasetBuildConfig) -> tuple[str, ...]:
         cha_columns = selected_columns("CHA", allowed_statuses=(CONFIRMED,))
         sed_columns = selected_columns("SED", allowed_statuses=(CONFIRMED, "provisional"))
         return (
-            f"TRY_CAST(r.{sed_columns['win_odds']} AS DOUBLE) AS win_odds",
+            "w.win_odds AS win_odds",
             f"r.{sed_columns['popularity']} AS popularity",
             "DATE_DIFF('day', c.workout_date, b.race_date) AS workout_gap_days",
             f"{workout_weekday_case_sql(cha_columns['workout_weekday'])} AS workout_weekday_code",
@@ -310,7 +302,7 @@ def market_feature_select_parts(
     sed_columns: dict[str, str],
     oz_columns: dict[str, str],
 ) -> tuple[str, ...]:
-    win_odds_sql = f"TRY_CAST(r.{sed_columns['win_odds']} AS DOUBLE) AS win_odds"
+    win_odds_sql = "w.win_odds AS win_odds"
     popularity_sql = f"r.{sed_columns['popularity']} AS popularity"
     place_basis_sql = (
         f"TRY_CAST(o.{oz_columns['place_basis_odds']} AS DOUBLE) AS place_basis_odds"
@@ -366,7 +358,7 @@ def market_feature_select_parts(
             popularity_sql,
             (
                 "LN(TRY_CAST(o.place_basis_odds AS DOUBLE)) "
-                "- LN(TRY_CAST(r.win_odds AS DOUBLE)) AS log_place_minus_log_win"
+                "- LN(w.win_odds) AS log_place_minus_log_win"
             ),
         )
     if feature_set == "dual_market_plus_implied_probs":
@@ -379,7 +371,7 @@ def market_feature_select_parts(
                 "AS implied_place_prob"
             ),
             (
-                "1.0 / NULLIF(TRY_CAST(r.win_odds AS DOUBLE), 0.0) "
+                "1.0 / NULLIF(w.win_odds, 0.0) "
                 "AS implied_win_prob"
             ),
         )
@@ -390,7 +382,7 @@ def market_feature_select_parts(
             popularity_sql,
             (
                 "(1.0 / NULLIF(TRY_CAST(o.place_basis_odds AS DOUBLE), 0.0)) "
-                "- (1.0 / NULLIF(TRY_CAST(r.win_odds AS DOUBLE), 0.0)) "
+                "- (1.0 / NULLIF(w.win_odds, 0.0)) "
                 "AS implied_place_prob_minus_implied_win_prob"
             ),
         )
@@ -401,19 +393,18 @@ def market_feature_select_parts(
             popularity_sql,
             (
                 "TRY_CAST(o.place_basis_odds AS DOUBLE) "
-                "/ NULLIF(TRY_CAST(r.win_odds AS DOUBLE), 0.0) AS place_to_win_ratio"
+                "/ NULLIF(w.win_odds, 0.0) AS place_to_win_ratio"
             ),
         )
     raise ValueError(f"unsupported market feature_set: {feature_set}")
 
 
 def processed_columns(config: DatasetBuildConfig) -> tuple[str, ...]:
-    feature_columns = FEATURE_SET_COLUMNS.get(config.feature_set)
-    if feature_columns is None:
-        raise ValueError(f"unsupported feature_set: {config.feature_set}")
+    feature_columns = dataset_feature_columns(
+        config.feature_set,
+        include_popularity=config.include_popularity,
+    )
     columns = METADATA_COLUMNS + feature_columns + TARGET_COLUMNS
-    if config.feature_set == "odds_only" and config.include_popularity:
-        return METADATA_COLUMNS + ("win_odds", "popularity") + TARGET_COLUMNS
     return columns
 
 

--- a/src/horse_bet_lab/evaluation/place_backtest.py
+++ b/src/horse_bet_lab/evaluation/place_backtest.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import duckdb
 
 from horse_bet_lab.config import PlaceBacktestConfig
+from horse_bet_lab.features.provenance import build_feature_provenance_payload
 from horse_bet_lab.model.service import RollingPairWindow, generate_rolling_pair_predictions
 
 SPLIT_ORDER = ("train", "valid", "test")
@@ -602,6 +603,10 @@ def run_place_backtest(config: PlaceBacktestConfig) -> PlaceBacktestResult:
         config.output_dir / "monthly_place_basis_buckets.json",
         config,
         place_basis_bucket_summaries,
+    )
+    write_place_backtest_provenance_manifest(
+        config.output_dir / "feature_provenance.json",
+        config,
     )
     return PlaceBacktestResult(
         output_dir=config.output_dir,
@@ -2568,6 +2573,11 @@ def write_place_backtest_json(
     summaries: tuple[PlaceBacktestSummary, ...],
 ) -> None:
     payload = {
+        "provenance": build_place_backtest_provenance(
+            config,
+            artifact_kind="place_backtest_summary_json",
+            artifact_path=path,
+        ),
         "backtest": {
             "name": config.name,
             "predictions_path": str(config.predictions_path),
@@ -2642,6 +2652,46 @@ def write_place_backtest_json(
         },
         "summaries": [asdict(summary) for summary in summaries],
     }
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def build_place_backtest_provenance(
+    config: PlaceBacktestConfig,
+    *,
+    artifact_kind: str,
+    artifact_path: Path,
+) -> dict[str, object]:
+    model_feature_columns = (
+        config.rolling_feature_columns
+        if config.rolling_retrain_dataset_path is not None and config.rolling_feature_columns
+        else None
+    )
+    return build_feature_provenance_payload(
+        artifact_kind=artifact_kind,
+        generated_by="horse_bet_lab.evaluation.place_backtest.run_place_backtest",
+        config_identifier=config.name,
+        model_feature_columns=model_feature_columns,
+        artifact_path=str(artifact_path),
+        extra={
+            "predictions_path": str(config.predictions_path),
+            "duckdb_path": str(config.duckdb_path),
+            "selection_metric": config.selection_metric,
+            "market_prob_method": config.market_prob_method,
+            "rolling_retrain_dataset_path": (
+                str(config.rolling_retrain_dataset_path)
+                if config.rolling_retrain_dataset_path is not None
+                else None
+            ),
+        },
+    )
+
+
+def write_place_backtest_provenance_manifest(path: Path, config: PlaceBacktestConfig) -> None:
+    payload = build_place_backtest_provenance(
+        config,
+        artifact_kind="place_backtest_output_dir",
+        artifact_path=path,
+    )
     path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
 
 

--- a/src/horse_bet_lab/features/__init__.py
+++ b/src/horse_bet_lab/features/__init__.py
@@ -1,0 +1,43 @@
+from horse_bet_lab.features.registry import (
+    DATASET_FEATURE_SET_REGISTRY,
+    FEATURE_REGISTRY,
+    DatasetFeatureSetDefinition,
+    FeatureDefinition,
+    dataset_feature_columns,
+    dataset_feature_set_names,
+    model_feature_sequence_supported,
+    supported_model_feature_sequences,
+    validate_dataset_feature_set,
+    validate_feature_names,
+    validate_model_feature_columns,
+    validate_model_feature_columns_for_dataset_feature_set,
+)
+from horse_bet_lab.features.provenance import (
+    FEATURE_CONTRACT_VERSION,
+    build_feature_provenance_payload,
+    build_feature_source_summary,
+    dataset_model_feature_columns,
+    provenance_sidecar_path,
+    write_feature_provenance_sidecar,
+)
+
+__all__ = [
+    "DATASET_FEATURE_SET_REGISTRY",
+    "FEATURE_REGISTRY",
+    "DatasetFeatureSetDefinition",
+    "FeatureDefinition",
+    "FEATURE_CONTRACT_VERSION",
+    "dataset_feature_columns",
+    "dataset_model_feature_columns",
+    "dataset_feature_set_names",
+    "build_feature_provenance_payload",
+    "build_feature_source_summary",
+    "provenance_sidecar_path",
+    "model_feature_sequence_supported",
+    "supported_model_feature_sequences",
+    "validate_dataset_feature_set",
+    "validate_feature_names",
+    "validate_model_feature_columns",
+    "validate_model_feature_columns_for_dataset_feature_set",
+    "write_feature_provenance_sidecar",
+]

--- a/src/horse_bet_lab/features/provenance.py
+++ b/src/horse_bet_lab/features/provenance.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from horse_bet_lab.features.registry import (
+    DATASET_FEATURE_SET_REGISTRY,
+    FEATURE_REGISTRY,
+    dataset_feature_columns,
+)
+
+FEATURE_CONTRACT_VERSION = "v1"
+
+
+def dataset_model_feature_columns(
+    feature_set: str,
+    *,
+    include_popularity: bool = False,
+) -> tuple[str, ...] | None:
+    definition = DATASET_FEATURE_SET_REGISTRY[feature_set]
+    if include_popularity and definition.optional_model_parity_columns is not None:
+        return definition.optional_model_parity_columns
+    return definition.model_parity_columns
+
+
+def build_feature_source_summary(feature_names: tuple[str, ...]) -> dict[str, Any]:
+    if not feature_names:
+        return {
+            "feature_count": 0,
+            "by_source_class": {},
+            "by_timing_class": {},
+            "by_carrier_identity": {},
+            "numeric_feature_count": 0,
+            "dataset_feature_count": 0,
+            "model_parity_feature_count": 0,
+        }
+
+    by_source_class: dict[str, int] = {}
+    by_timing_class: dict[str, int] = {}
+    by_carrier_identity: dict[str, int] = {}
+    numeric_feature_count = 0
+    dataset_feature_count = 0
+    model_parity_feature_count = 0
+    for feature_name in feature_names:
+        definition = FEATURE_REGISTRY[feature_name]
+        by_source_class[definition.source_class] = by_source_class.get(definition.source_class, 0) + 1
+        by_timing_class[definition.timing_class] = by_timing_class.get(definition.timing_class, 0) + 1
+        by_carrier_identity[definition.carrier_identity] = (
+            by_carrier_identity.get(definition.carrier_identity, 0) + 1
+        )
+        if definition.numeric_or_not:
+            numeric_feature_count += 1
+        if definition.in_dataset:
+            dataset_feature_count += 1
+        if definition.in_model_parity_path:
+            model_parity_feature_count += 1
+    return {
+        "feature_count": len(feature_names),
+        "by_source_class": by_source_class,
+        "by_timing_class": by_timing_class,
+        "by_carrier_identity": by_carrier_identity,
+        "numeric_feature_count": numeric_feature_count,
+        "dataset_feature_count": dataset_feature_count,
+        "model_parity_feature_count": model_parity_feature_count,
+    }
+
+
+def build_feature_definitions(feature_names: tuple[str, ...]) -> list[dict[str, Any]]:
+    return [
+        {
+            "canonical_name": feature_name,
+            "in_dataset": FEATURE_REGISTRY[feature_name].in_dataset,
+            "in_model_parity_path": FEATURE_REGISTRY[feature_name].in_model_parity_path,
+            "numeric_or_not": FEATURE_REGISTRY[feature_name].numeric_or_not,
+            "source_class": FEATURE_REGISTRY[feature_name].source_class,
+            "timing_class": FEATURE_REGISTRY[feature_name].timing_class,
+            "carrier_identity": FEATURE_REGISTRY[feature_name].carrier_identity,
+            "leakage_allowed": FEATURE_REGISTRY[feature_name].leakage_allowed,
+        }
+        for feature_name in feature_names
+    ]
+
+
+def build_feature_provenance_payload(
+    *,
+    artifact_kind: str,
+    generated_by: str,
+    config_identifier: str,
+    dataset_feature_set: str | None = None,
+    include_popularity: bool = False,
+    model_feature_columns: tuple[str, ...] | None = None,
+    config_path: str | None = None,
+    artifact_path: str | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    dataset_columns: tuple[str, ...] | None = None
+    if dataset_feature_set is not None:
+        dataset_columns = dataset_feature_columns(
+            dataset_feature_set,
+            include_popularity=include_popularity,
+        )
+    feature_columns_order = (
+        model_feature_columns
+        if model_feature_columns is not None
+        else dataset_columns
+        if dataset_columns is not None
+        else ()
+    )
+    payload: dict[str, Any] = {
+        "feature_contract_version": FEATURE_CONTRACT_VERSION,
+        "artifact_kind": artifact_kind,
+        "generated_by": generated_by,
+        "config_identifier": config_identifier,
+        "config_path": config_path,
+        "artifact_path": artifact_path,
+        "dataset_feature_set": dataset_feature_set,
+        "dataset_feature_columns": list(dataset_columns) if dataset_columns is not None else None,
+        "model_feature_columns": list(model_feature_columns) if model_feature_columns is not None else None,
+        "feature_columns_order": list(feature_columns_order),
+        "feature_source_summary": build_feature_source_summary(feature_columns_order),
+        "feature_definitions": build_feature_definitions(feature_columns_order),
+        "registry_interpretation": "horse_bet_lab.features.registry",
+    }
+    if extra:
+        payload["extra"] = extra
+    return payload
+
+
+def provenance_sidecar_path(artifact_path: Path) -> Path:
+    return artifact_path.with_name(f"{artifact_path.name}.provenance.json")
+
+
+def write_feature_provenance_sidecar(artifact_path: Path, payload: dict[str, Any]) -> Path:
+    output_path = provenance_sidecar_path(artifact_path)
+    output_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    return output_path

--- a/src/horse_bet_lab/features/registry.py
+++ b/src/horse_bet_lab/features/registry.py
@@ -1,0 +1,563 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class FeatureDefinition:
+    canonical_name: str
+    in_dataset: bool
+    in_model_parity_path: bool
+    numeric_or_not: bool
+    source_class: str
+    timing_class: str
+    carrier_identity: str
+    leakage_allowed: bool
+
+
+@dataclass(frozen=True)
+class DatasetFeatureSetDefinition:
+    name: str
+    dataset_columns: tuple[str, ...]
+    model_parity_columns: tuple[str, ...] | None
+    optional_dataset_columns: tuple[str, ...] = ()
+    optional_model_parity_columns: tuple[str, ...] | None = None
+
+
+FEATURE_REGISTRY: dict[str, FeatureDefinition] = {
+    "distance_m": FeatureDefinition(
+        canonical_name="distance_m",
+        in_dataset=True,
+        in_model_parity_path=True,
+        numeric_or_not=True,
+        source_class="upstream_raw_structural",
+        timing_class="pre_race",
+        carrier_identity="jrdb_bac_staging",
+        leakage_allowed=True,
+    ),
+    "race_name": FeatureDefinition(
+        canonical_name="race_name",
+        in_dataset=True,
+        in_model_parity_path=False,
+        numeric_or_not=False,
+        source_class="upstream_raw_structural",
+        timing_class="pre_race",
+        carrier_identity="jrdb_bac_staging",
+        leakage_allowed=True,
+    ),
+    "workout_weekday": FeatureDefinition(
+        canonical_name="workout_weekday",
+        in_dataset=True,
+        in_model_parity_path=False,
+        numeric_or_not=False,
+        source_class="upstream_raw_workout",
+        timing_class="pre_race",
+        carrier_identity="jrdb_cha_staging",
+        leakage_allowed=True,
+    ),
+    "workout_date": FeatureDefinition(
+        canonical_name="workout_date",
+        in_dataset=True,
+        in_model_parity_path=False,
+        numeric_or_not=False,
+        source_class="upstream_raw_workout",
+        timing_class="pre_race",
+        carrier_identity="jrdb_cha_staging",
+        leakage_allowed=True,
+    ),
+    "win_odds": FeatureDefinition(
+        canonical_name="win_odds",
+        in_dataset=True,
+        in_model_parity_path=True,
+        numeric_or_not=True,
+        source_class="upstream_raw_market",
+        timing_class="pre_race",
+        carrier_identity="win_market_snapshot_v1",
+        leakage_allowed=True,
+    ),
+    "popularity": FeatureDefinition(
+        canonical_name="popularity",
+        in_dataset=True,
+        in_model_parity_path=True,
+        numeric_or_not=True,
+        source_class="upstream_raw_market",
+        timing_class="pre_race_semantic_post_race_carrier",
+        carrier_identity="legacy_sed_only",
+        leakage_allowed=True,
+    ),
+    "place_basis_odds": FeatureDefinition(
+        canonical_name="place_basis_odds",
+        in_dataset=True,
+        in_model_parity_path=True,
+        numeric_or_not=True,
+        source_class="upstream_raw_market",
+        timing_class="pre_race",
+        carrier_identity="jrdb_oz_staging",
+        leakage_allowed=True,
+    ),
+    "headcount": FeatureDefinition(
+        canonical_name="headcount",
+        in_dataset=True,
+        in_model_parity_path=True,
+        numeric_or_not=True,
+        source_class="upstream_raw_market_support",
+        timing_class="pre_race",
+        carrier_identity="jrdb_oz_staging",
+        leakage_allowed=True,
+    ),
+    "workout_gap_days": FeatureDefinition(
+        canonical_name="workout_gap_days",
+        in_dataset=True,
+        in_model_parity_path=True,
+        numeric_or_not=True,
+        source_class="project_derived_workout",
+        timing_class="pre_race",
+        carrier_identity="derived_from_bac_cha",
+        leakage_allowed=True,
+    ),
+    "workout_weekday_code": FeatureDefinition(
+        canonical_name="workout_weekday_code",
+        in_dataset=True,
+        in_model_parity_path=True,
+        numeric_or_not=True,
+        source_class="project_derived_workout",
+        timing_class="pre_race",
+        carrier_identity="derived_from_bac_cha",
+        leakage_allowed=True,
+    ),
+    "place_slot_count": FeatureDefinition(
+        canonical_name="place_slot_count",
+        in_dataset=True,
+        in_model_parity_path=True,
+        numeric_or_not=True,
+        source_class="project_derived_market",
+        timing_class="pre_race",
+        carrier_identity="derived_from_oz",
+        leakage_allowed=True,
+    ),
+    "log_place_minus_log_win": FeatureDefinition(
+        canonical_name="log_place_minus_log_win",
+        in_dataset=True,
+        in_model_parity_path=True,
+        numeric_or_not=True,
+        source_class="project_derived_market",
+        timing_class="pre_race",
+        carrier_identity="derived_from_win_market_snapshot_v1_and_oz",
+        leakage_allowed=True,
+    ),
+    "implied_place_prob": FeatureDefinition(
+        canonical_name="implied_place_prob",
+        in_dataset=True,
+        in_model_parity_path=True,
+        numeric_or_not=True,
+        source_class="project_derived_market",
+        timing_class="pre_race",
+        carrier_identity="derived_from_oz",
+        leakage_allowed=True,
+    ),
+    "implied_win_prob": FeatureDefinition(
+        canonical_name="implied_win_prob",
+        in_dataset=True,
+        in_model_parity_path=True,
+        numeric_or_not=True,
+        source_class="project_derived_market",
+        timing_class="pre_race",
+        carrier_identity="derived_from_win_market_snapshot_v1",
+        leakage_allowed=True,
+    ),
+    "implied_place_prob_minus_implied_win_prob": FeatureDefinition(
+        canonical_name="implied_place_prob_minus_implied_win_prob",
+        in_dataset=True,
+        in_model_parity_path=True,
+        numeric_or_not=True,
+        source_class="project_derived_market",
+        timing_class="pre_race",
+        carrier_identity="derived_from_win_market_snapshot_v1_and_oz",
+        leakage_allowed=True,
+    ),
+    "place_to_win_ratio": FeatureDefinition(
+        canonical_name="place_to_win_ratio",
+        in_dataset=True,
+        in_model_parity_path=True,
+        numeric_or_not=True,
+        source_class="project_derived_market",
+        timing_class="pre_race",
+        carrier_identity="derived_from_win_market_snapshot_v1_and_oz",
+        leakage_allowed=True,
+    ),
+    "finish_position": FeatureDefinition(
+        canonical_name="finish_position",
+        in_dataset=False,
+        in_model_parity_path=False,
+        numeric_or_not=True,
+        source_class="result_side",
+        timing_class="post_race",
+        carrier_identity="jrdb_sed_staging",
+        leakage_allowed=False,
+    ),
+    "result_date": FeatureDefinition(
+        canonical_name="result_date",
+        in_dataset=False,
+        in_model_parity_path=False,
+        numeric_or_not=False,
+        source_class="result_side",
+        timing_class="post_race",
+        carrier_identity="jrdb_sed_staging",
+        leakage_allowed=False,
+    ),
+    "win_payout": FeatureDefinition(
+        canonical_name="win_payout",
+        in_dataset=False,
+        in_model_parity_path=False,
+        numeric_or_not=True,
+        source_class="result_side",
+        timing_class="post_race",
+        carrier_identity="jrdb_hjc_staging",
+        leakage_allowed=False,
+    ),
+    "place_payout_1": FeatureDefinition(
+        canonical_name="place_payout_1",
+        in_dataset=False,
+        in_model_parity_path=False,
+        numeric_or_not=True,
+        source_class="result_side",
+        timing_class="post_race",
+        carrier_identity="jrdb_hjc_staging",
+        leakage_allowed=False,
+    ),
+    "place_payout_2": FeatureDefinition(
+        canonical_name="place_payout_2",
+        in_dataset=False,
+        in_model_parity_path=False,
+        numeric_or_not=True,
+        source_class="result_side",
+        timing_class="post_race",
+        carrier_identity="jrdb_hjc_staging",
+        leakage_allowed=False,
+    ),
+    "place_payout_3": FeatureDefinition(
+        canonical_name="place_payout_3",
+        in_dataset=False,
+        in_model_parity_path=False,
+        numeric_or_not=True,
+        source_class="result_side",
+        timing_class="post_race",
+        carrier_identity="jrdb_hjc_staging",
+        leakage_allowed=False,
+    ),
+}
+
+
+DATASET_FEATURE_SET_REGISTRY: dict[str, DatasetFeatureSetDefinition] = {
+    "minimal": DatasetFeatureSetDefinition(
+        name="minimal",
+        dataset_columns=("distance_m", "race_name", "workout_weekday", "workout_date"),
+        model_parity_columns=None,
+    ),
+    "odds_only": DatasetFeatureSetDefinition(
+        name="odds_only",
+        dataset_columns=("win_odds",),
+        model_parity_columns=("win_odds",),
+        optional_dataset_columns=("popularity",),
+        optional_model_parity_columns=("win_odds", "popularity"),
+    ),
+    "win_market_only": DatasetFeatureSetDefinition(
+        name="win_market_only",
+        dataset_columns=("win_odds", "popularity"),
+        model_parity_columns=("win_odds", "popularity"),
+    ),
+    "current_win_market": DatasetFeatureSetDefinition(
+        name="current_win_market",
+        dataset_columns=("win_odds", "popularity"),
+        model_parity_columns=("win_odds", "popularity"),
+    ),
+    "place_market_only": DatasetFeatureSetDefinition(
+        name="place_market_only",
+        dataset_columns=("place_basis_odds",),
+        model_parity_columns=("place_basis_odds",),
+    ),
+    "place_market_plus_popularity": DatasetFeatureSetDefinition(
+        name="place_market_plus_popularity",
+        dataset_columns=("place_basis_odds", "popularity"),
+        model_parity_columns=("place_basis_odds", "popularity"),
+    ),
+    "dual_market": DatasetFeatureSetDefinition(
+        name="dual_market",
+        dataset_columns=("win_odds", "place_basis_odds", "popularity"),
+        model_parity_columns=("win_odds", "place_basis_odds", "popularity"),
+    ),
+    "dual_market_for_win": DatasetFeatureSetDefinition(
+        name="dual_market_for_win",
+        dataset_columns=("win_odds", "place_basis_odds", "popularity"),
+        model_parity_columns=("win_odds", "place_basis_odds", "popularity"),
+    ),
+    "dual_market_plus_headcount": DatasetFeatureSetDefinition(
+        name="dual_market_plus_headcount",
+        dataset_columns=("win_odds", "place_basis_odds", "popularity", "headcount"),
+        model_parity_columns=("win_odds", "place_basis_odds", "popularity", "headcount"),
+    ),
+    "dual_market_plus_headcount_place_slots": DatasetFeatureSetDefinition(
+        name="dual_market_plus_headcount_place_slots",
+        dataset_columns=(
+            "win_odds",
+            "place_basis_odds",
+            "popularity",
+            "headcount",
+            "place_slot_count",
+        ),
+        model_parity_columns=(
+            "win_odds",
+            "place_basis_odds",
+            "popularity",
+            "headcount",
+            "place_slot_count",
+        ),
+    ),
+    "dual_market_plus_headcount_place_slots_distance": DatasetFeatureSetDefinition(
+        name="dual_market_plus_headcount_place_slots_distance",
+        dataset_columns=(
+            "win_odds",
+            "place_basis_odds",
+            "popularity",
+            "headcount",
+            "place_slot_count",
+            "distance_m",
+        ),
+        model_parity_columns=(
+            "win_odds",
+            "place_basis_odds",
+            "popularity",
+            "headcount",
+            "place_slot_count",
+            "distance_m",
+        ),
+    ),
+    "dual_market_plus_log_diff": DatasetFeatureSetDefinition(
+        name="dual_market_plus_log_diff",
+        dataset_columns=("win_odds", "place_basis_odds", "popularity", "log_place_minus_log_win"),
+        model_parity_columns=(
+            "win_odds",
+            "place_basis_odds",
+            "popularity",
+            "log_place_minus_log_win",
+        ),
+    ),
+    "dual_market_plus_implied_probs": DatasetFeatureSetDefinition(
+        name="dual_market_plus_implied_probs",
+        dataset_columns=(
+            "win_odds",
+            "place_basis_odds",
+            "popularity",
+            "implied_place_prob",
+            "implied_win_prob",
+        ),
+        model_parity_columns=(
+            "win_odds",
+            "place_basis_odds",
+            "popularity",
+            "implied_place_prob",
+            "implied_win_prob",
+        ),
+    ),
+    "dual_market_plus_prob_diff": DatasetFeatureSetDefinition(
+        name="dual_market_plus_prob_diff",
+        dataset_columns=(
+            "win_odds",
+            "place_basis_odds",
+            "popularity",
+            "implied_place_prob_minus_implied_win_prob",
+        ),
+        model_parity_columns=(
+            "win_odds",
+            "place_basis_odds",
+            "popularity",
+            "implied_place_prob_minus_implied_win_prob",
+        ),
+    ),
+    "dual_market_plus_ratio": DatasetFeatureSetDefinition(
+        name="dual_market_plus_ratio",
+        dataset_columns=("win_odds", "place_basis_odds", "popularity", "place_to_win_ratio"),
+        model_parity_columns=(
+            "win_odds",
+            "place_basis_odds",
+            "popularity",
+            "place_to_win_ratio",
+        ),
+    ),
+    "market_plus_workout_minimal": DatasetFeatureSetDefinition(
+        name="market_plus_workout_minimal",
+        dataset_columns=("win_odds", "popularity", "workout_gap_days", "workout_weekday_code"),
+        model_parity_columns=("win_odds", "popularity", "workout_gap_days", "workout_weekday_code"),
+    ),
+}
+
+
+def dataset_feature_set_names() -> tuple[str, ...]:
+    return tuple(DATASET_FEATURE_SET_REGISTRY)
+
+
+def validate_dataset_feature_set(feature_set: str, *, include_popularity: bool = False) -> None:
+    definition = DATASET_FEATURE_SET_REGISTRY.get(feature_set)
+    if definition is None:
+        supported = ", ".join(sorted(DATASET_FEATURE_SET_REGISTRY))
+        raise ValueError(
+            f"unsupported dataset_feature_set: {feature_set!r}; supported feature_sets: {supported}",
+        )
+    if include_popularity and not definition.optional_dataset_columns:
+        raise ValueError(
+            f"dataset_feature_set {feature_set!r} does not support include_popularity=true",
+        )
+    validate_feature_names(
+        dataset_feature_columns(feature_set, include_popularity=include_popularity),
+        context=f"dataset_feature_set {feature_set!r}",
+        require_in_dataset=True,
+    )
+
+
+def dataset_feature_columns(feature_set: str, *, include_popularity: bool = False) -> tuple[str, ...]:
+    definition = DATASET_FEATURE_SET_REGISTRY.get(feature_set)
+    if definition is None:
+        supported = ", ".join(sorted(DATASET_FEATURE_SET_REGISTRY))
+        raise ValueError(
+            f"unsupported dataset_feature_set: {feature_set!r}; supported feature_sets: {supported}",
+        )
+    if include_popularity and not definition.optional_dataset_columns:
+        raise ValueError(
+            f"dataset_feature_set {feature_set!r} does not support include_popularity=true",
+        )
+    if include_popularity:
+        return definition.dataset_columns + definition.optional_dataset_columns
+    return definition.dataset_columns
+
+
+def supported_model_feature_sequences() -> tuple[tuple[str, ...], ...]:
+    sequences: list[tuple[str, ...]] = []
+    for definition in DATASET_FEATURE_SET_REGISTRY.values():
+        if definition.model_parity_columns is not None:
+            sequences.append(definition.model_parity_columns)
+        if definition.optional_model_parity_columns is not None:
+            sequences.append(definition.optional_model_parity_columns)
+    seen: set[tuple[str, ...]] = set()
+    ordered: list[tuple[str, ...]] = []
+    for sequence in sequences:
+        if sequence not in seen:
+            seen.add(sequence)
+            ordered.append(sequence)
+    return tuple(ordered)
+
+
+def model_feature_sequence_supported(feature_columns: tuple[str, ...]) -> bool:
+    return feature_columns in set(supported_model_feature_sequences())
+
+
+def validate_feature_names(
+    feature_names: tuple[str, ...],
+    *,
+    context: str,
+    require_in_dataset: bool = False,
+    require_model_parity: bool = False,
+    require_numeric: bool = False,
+) -> None:
+    unknown_features = sorted(set(feature_names) - set(FEATURE_REGISTRY))
+    if unknown_features:
+        raise ValueError(f"{context} contains unknown features: {unknown_features}")
+
+    forbidden_leakage_features = sorted(
+        {
+            name
+            for name in feature_names
+            if not FEATURE_REGISTRY[name].leakage_allowed
+        }
+    )
+    if forbidden_leakage_features:
+        raise ValueError(
+            f"{context} contains forbidden post-race/result-side features: "
+            f"{forbidden_leakage_features}",
+        )
+
+    if require_in_dataset:
+        not_in_dataset = sorted({name for name in feature_names if not FEATURE_REGISTRY[name].in_dataset})
+        if not_in_dataset:
+            raise ValueError(f"{context} contains features not allowed in dataset: {not_in_dataset}")
+
+    if require_model_parity:
+        not_in_model_parity = sorted(
+            {name for name in feature_names if not FEATURE_REGISTRY[name].in_model_parity_path},
+        )
+        if not_in_model_parity:
+            raise ValueError(
+                f"{context} contains features not allowed in model parity path: "
+                f"{not_in_model_parity}",
+            )
+
+    if require_numeric:
+        non_numeric_features = sorted(
+            {name for name in feature_names if not FEATURE_REGISTRY[name].numeric_or_not},
+        )
+        if non_numeric_features:
+            raise ValueError(
+                f"{context} contains non-numeric features not allowed in numeric model path: "
+                f"{non_numeric_features}",
+            )
+
+
+def validate_model_feature_columns(
+    feature_columns: tuple[str, ...],
+    *,
+    context: str,
+) -> None:
+    validate_feature_names(
+        feature_columns,
+        context=context,
+        require_in_dataset=True,
+        require_model_parity=True,
+        require_numeric=True,
+    )
+    if not model_feature_sequence_supported(feature_columns):
+        supported = [list(sequence) for sequence in supported_model_feature_sequences()]
+        raise ValueError(
+            f"{context} is not a supported parity-safe feature sequence: {list(feature_columns)}; "
+            f"supported sequences: {supported}",
+        )
+
+
+def validate_model_feature_columns_for_dataset_feature_set(
+    *,
+    dataset_feature_set: str,
+    include_popularity: bool,
+    feature_columns: tuple[str, ...],
+    context: str,
+) -> None:
+    validate_dataset_feature_set(dataset_feature_set, include_popularity=include_popularity)
+    definition = DATASET_FEATURE_SET_REGISTRY[dataset_feature_set]
+    expected_model_columns = (
+        definition.optional_model_parity_columns
+        if include_popularity and definition.optional_model_parity_columns is not None
+        else definition.model_parity_columns
+    )
+    if expected_model_columns is None:
+        raise ValueError(
+            f"dataset_feature_set {dataset_feature_set!r} is dataset-only and has no model parity path",
+        )
+    validate_feature_names(
+        feature_columns,
+        context=context,
+        require_in_dataset=True,
+        require_model_parity=True,
+        require_numeric=True,
+    )
+    if feature_columns != expected_model_columns:
+        raise ValueError(
+            f"{context} must match dataset_feature_set {dataset_feature_set!r}: "
+            f"expected {list(expected_model_columns)}, got {list(feature_columns)}",
+        )
+    expected_columns = dataset_feature_columns(
+        dataset_feature_set,
+        include_popularity=include_popularity,
+    )
+    missing_from_dataset = sorted(set(feature_columns) - set(expected_columns))
+    if missing_from_dataset:
+        raise ValueError(
+            f"{context} contains features not produced by dataset_feature_set "
+            f"{dataset_feature_set!r}: {missing_from_dataset}",
+        )

--- a/src/horse_bet_lab/model/service.py
+++ b/src/horse_bet_lab/model/service.py
@@ -18,6 +18,11 @@ from sklearn.metrics import (  # type: ignore[import-untyped]
 )
 
 from horse_bet_lab.config import ModelTrainConfig
+from horse_bet_lab.features.provenance import (
+    build_feature_provenance_payload,
+    write_feature_provenance_sidecar,
+)
+from horse_bet_lab.features.registry import validate_model_feature_columns
 
 SPLIT_ORDER = ("train", "valid", "test")
 PREDICTION_COLUMNS = (
@@ -105,8 +110,40 @@ def train_logistic_regression_baseline(config: ModelTrainConfig) -> ModelTrainSu
         )
 
     write_metrics_artifact(config, model, metrics_by_split)
-    write_predictions_artifact(config.output_dir / "predictions.csv", prediction_rows)
-    write_calibration_artifact(config.output_dir / "calibration.csv", calibration_rows)
+    write_predictions_artifact(
+        config.output_dir / "predictions.csv",
+        prediction_rows,
+        provenance_payload=build_feature_provenance_payload(
+            artifact_kind="prediction_csv",
+            generated_by="horse_bet_lab.model.service.train_logistic_regression_baseline",
+            config_identifier=config.name,
+            model_feature_columns=config.feature_columns,
+            artifact_path=str(config.output_dir / "predictions.csv"),
+            extra={
+                "dataset_path": str(config.dataset_path),
+                "model_name": config.model_name,
+                "target_column": config.target_column,
+                "split_column": config.split_column,
+            },
+        ),
+    )
+    write_calibration_artifact(
+        config.output_dir / "calibration.csv",
+        calibration_rows,
+        provenance_payload=build_feature_provenance_payload(
+            artifact_kind="calibration_csv",
+            generated_by="horse_bet_lab.model.service.train_logistic_regression_baseline",
+            config_identifier=config.name,
+            model_feature_columns=config.feature_columns,
+            artifact_path=str(config.output_dir / "calibration.csv"),
+            extra={
+                "dataset_path": str(config.dataset_path),
+                "model_name": config.model_name,
+                "target_column": config.target_column,
+                "split_column": config.split_column,
+            },
+        ),
+    )
 
     return ModelTrainSummary(output_dir=config.output_dir, metrics_by_split=metrics_by_split)
 
@@ -224,7 +261,24 @@ def generate_rolling_pair_predictions(
                 ),
             )
 
-    write_predictions_artifact(output_path, prediction_rows)
+    write_predictions_artifact(
+        output_path,
+        prediction_rows,
+        provenance_payload=build_feature_provenance_payload(
+            artifact_kind="rolling_prediction_csv",
+            generated_by="horse_bet_lab.model.service.generate_rolling_pair_predictions",
+            config_identifier=output_path.stem,
+            model_feature_columns=feature_columns,
+            artifact_path=str(output_path),
+            extra={
+                "dataset_path": str(dataset_path),
+                "model_name": model_name,
+                "target_column": target_column,
+                "race_date_column": race_date_column,
+                "evaluation_window_pair_count": len(evaluation_window_pairs),
+            },
+        ),
+    )
     return output_path
 
 
@@ -241,52 +295,10 @@ def validate_model_feature_spec(
     feature_columns: tuple[str, ...],
     feature_transforms: tuple[str, ...],
 ) -> None:
-    supported_feature_sets = {
-        ("win_odds",),
-        ("win_odds", "popularity"),
-        ("place_basis_odds",),
-        ("place_basis_odds", "popularity"),
-        ("win_odds", "place_basis_odds", "popularity"),
-        ("win_odds", "place_basis_odds", "popularity", "headcount"),
-        ("win_odds", "place_basis_odds", "popularity", "headcount", "place_slot_count"),
-        (
-            "win_odds",
-            "place_basis_odds",
-            "popularity",
-            "headcount",
-            "place_slot_count",
-            "distance_m",
-        ),
-        ("win_odds", "place_basis_odds", "popularity", "log_place_minus_log_win"),
-        ("win_odds", "place_basis_odds", "popularity", "implied_place_prob", "implied_win_prob"),
-        (
-            "win_odds",
-            "place_basis_odds",
-            "popularity",
-            "implied_place_prob_minus_implied_win_prob",
-        ),
-        ("win_odds", "place_basis_odds", "popularity", "place_to_win_ratio"),
-        ("win_odds", "popularity", "workout_gap_days", "workout_weekday_code"),
-    }
-    if feature_columns not in supported_feature_sets:
-        raise ValueError(
-            "baseline model currently supports feature_columns=['win_odds'] "
-            "or ['win_odds', 'popularity'] "
-            "or ['place_basis_odds'] "
-            "or ['place_basis_odds', 'popularity'] "
-            "or ['win_odds', 'place_basis_odds', 'popularity'] "
-            "or ['win_odds', 'place_basis_odds', 'popularity', 'headcount'] "
-            "or ['win_odds', 'place_basis_odds', 'popularity', 'headcount', 'place_slot_count'] "
-            "or ['win_odds', 'place_basis_odds', 'popularity', 'headcount', "
-            "'place_slot_count', 'distance_m'] "
-            "or ['win_odds', 'place_basis_odds', 'popularity', 'log_place_minus_log_win'] "
-            "or ['win_odds', 'place_basis_odds', 'popularity', "
-            "'implied_place_prob', 'implied_win_prob'] "
-            "or ['win_odds', 'place_basis_odds', 'popularity', "
-            "'implied_place_prob_minus_implied_win_prob'] "
-            "or ['win_odds', 'place_basis_odds', 'popularity', 'place_to_win_ratio'] "
-            "or ['win_odds', 'popularity', 'workout_gap_days', 'workout_weekday_code'] only",
-        )
+    validate_model_feature_columns(
+        feature_columns,
+        context="model feature_columns",
+    )
     for column_name, transform_name in zip(
         feature_columns,
         feature_transforms,
@@ -598,6 +610,19 @@ def write_metrics_artifact(
             "max_iter": config.max_iter,
             "model_params": config.model_params,
         },
+        "provenance": build_feature_provenance_payload(
+            artifact_kind="training_metrics_json",
+            generated_by="horse_bet_lab.model.service.train_logistic_regression_baseline",
+            config_identifier=config.name,
+            model_feature_columns=config.feature_columns,
+            artifact_path=str(config.output_dir / "metrics.json"),
+            extra={
+                "dataset_path": str(config.dataset_path),
+                "model_name": config.model_name,
+                "target_column": config.target_column,
+                "split_column": config.split_column,
+            },
+        ),
         "model": model_payload,
         "metrics": {
             split_name: asdict(metrics)
@@ -610,14 +635,26 @@ def write_metrics_artifact(
     )
 
 
-def write_predictions_artifact(path: Path, rows: list[dict[str, object]]) -> None:
+def write_predictions_artifact(
+    path: Path,
+    rows: list[dict[str, object]],
+    *,
+    provenance_payload: dict[str, object] | None = None,
+) -> None:
     with path.open("w", encoding="utf-8", newline="") as file:
         writer = csv.DictWriter(file, fieldnames=PREDICTION_COLUMNS)
         writer.writeheader()
         writer.writerows(rows)
+    if provenance_payload is not None:
+        write_feature_provenance_sidecar(path, provenance_payload)
 
 
-def write_calibration_artifact(path: Path, rows: list[dict[str, object]]) -> None:
+def write_calibration_artifact(
+    path: Path,
+    rows: list[dict[str, object]],
+    *,
+    provenance_payload: dict[str, object] | None = None,
+) -> None:
     fieldnames = (
         "split",
         "bin_id",
@@ -631,6 +668,8 @@ def write_calibration_artifact(path: Path, rows: list[dict[str, object]]) -> Non
         writer = csv.DictWriter(file, fieldnames=fieldnames)
         writer.writeheader()
         writer.writerows(rows)
+    if provenance_payload is not None:
+        write_feature_provenance_sidecar(path, provenance_payload)
 
 
 def load_prediction_metrics(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,14 @@
 from pathlib import Path
 
-from horse_bet_lab.config import load_experiment_config
+import pytest
+
+from horse_bet_lab.config import (
+    load_dataset_build_config,
+    load_experiment_config,
+    load_market_feature_comparison_config,
+    load_model_train_config,
+    load_place_backtest_config,
+)
 
 
 def test_load_experiment_config() -> None:
@@ -12,3 +20,199 @@ def test_load_experiment_config() -> None:
     assert config.strategy == "flat"
     assert config.period == "2020-01-01_to_2020-12-31"
 
+
+def test_load_dataset_build_config_accepts_known_feature_set(tmp_path: Path) -> None:
+    config_path = tmp_path / "dataset.toml"
+    config_path.write_text(
+        (
+            "[dataset]\n"
+            "name = 'dataset_dual_market'\n"
+            "start_date = '2025-01-01'\n"
+            "end_date = '2025-12-31'\n"
+            "feature_set = 'dual_market'\n"
+            "target_name = 'is_place'\n"
+            "duckdb_path = 'data/artifacts/jrdb.duckdb'\n"
+            "output_path = 'data/processed/dataset.parquet'\n"
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_dataset_build_config(config_path)
+
+    assert config.feature_set == "dual_market"
+
+
+def test_load_dataset_build_config_rejects_unknown_feature_set(tmp_path: Path) -> None:
+    config_path = tmp_path / "dataset_invalid.toml"
+    config_path.write_text(
+        (
+            "[dataset]\n"
+            "name = 'dataset_invalid'\n"
+            "start_date = '2025-01-01'\n"
+            "end_date = '2025-12-31'\n"
+            "feature_set = 'unknown_feature_set'\n"
+            "target_name = 'is_place'\n"
+            "duckdb_path = 'data/artifacts/jrdb.duckdb'\n"
+            "output_path = 'data/processed/dataset.parquet'\n"
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="unsupported dataset_feature_set"):
+        load_dataset_build_config(config_path)
+
+
+def test_load_model_train_config_rejects_unknown_feature(tmp_path: Path) -> None:
+    config_path = tmp_path / "model_unknown.toml"
+    config_path.write_text(
+        (
+            "[training]\n"
+            "name = 'invalid_unknown_feature'\n"
+            "dataset_path = 'data/processed/dataset.parquet'\n"
+            "model_name = 'logistic_regression'\n"
+            "feature_columns = ['win_odds', 'mystery_feature']\n"
+            "feature_transforms = ['identity', 'identity']\n"
+            "output_dir = 'data/artifacts/invalid'\n"
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="unknown features"):
+        load_model_train_config(config_path)
+
+
+def test_load_model_train_config_rejects_dataset_only_feature_in_model_path(tmp_path: Path) -> None:
+    config_path = tmp_path / "model_dataset_only.toml"
+    config_path.write_text(
+        (
+            "[training]\n"
+            "name = 'invalid_dataset_only_feature'\n"
+            "dataset_path = 'data/processed/dataset.parquet'\n"
+            "model_name = 'logistic_regression'\n"
+            "feature_columns = ['win_odds', 'race_name']\n"
+            "feature_transforms = ['identity', 'identity']\n"
+            "output_dir = 'data/artifacts/invalid'\n"
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="features not allowed in model parity path"):
+        load_model_train_config(config_path)
+
+
+def test_load_model_train_config_rejects_forbidden_leakage_feature(tmp_path: Path) -> None:
+    config_path = tmp_path / "model_forbidden.toml"
+    config_path.write_text(
+        (
+            "[training]\n"
+            "name = 'invalid_forbidden_feature'\n"
+            "dataset_path = 'data/processed/dataset.parquet'\n"
+            "model_name = 'logistic_regression'\n"
+            "feature_columns = ['win_odds', 'finish_position']\n"
+            "feature_transforms = ['identity', 'identity']\n"
+            "output_dir = 'data/artifacts/invalid'\n"
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="forbidden post-race/result-side features"):
+        load_model_train_config(config_path)
+
+
+def test_load_model_train_config_accepts_valid_ordered_parity_sequence(tmp_path: Path) -> None:
+    config_path = tmp_path / "model_valid.toml"
+    config_path.write_text(
+        (
+            "[training]\n"
+            "name = 'valid_dual_market'\n"
+            "dataset_path = 'data/processed/dataset.parquet'\n"
+            "model_name = 'logistic_regression'\n"
+            "feature_columns = ['win_odds', 'place_basis_odds', 'popularity']\n"
+            "feature_transforms = ['log1p', 'log1p', 'identity']\n"
+            "output_dir = 'data/artifacts/valid'\n"
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_model_train_config(config_path)
+
+    assert config.feature_columns == ("win_odds", "place_basis_odds", "popularity")
+
+
+def test_load_market_feature_comparison_config_rejects_dataset_only_mismatch(tmp_path: Path) -> None:
+    config_path = tmp_path / "comparison_invalid.toml"
+    config_path.write_text(
+        (
+            "[comparison]\n"
+            "name = 'invalid_comparison'\n"
+            "duckdb_path = 'data/artifacts/jrdb.duckdb'\n"
+            "output_dir = 'data/artifacts/out'\n"
+            "start_date = '2025-01-01'\n"
+            "end_date = '2025-12-31'\n"
+            "target_name = 'is_place'\n"
+            "backtest_template_config_path = 'configs/place_backtest_odds_log1p_plus_popularity.toml'\n"
+            "aggregate_selection_score_rule = 'mean_valid_roi'\n"
+            "\n"
+            "[[comparison.feature_sets]]\n"
+            "name = 'invalid_minimal'\n"
+            "dataset_feature_set = 'minimal'\n"
+            "model_name = 'logistic_regression'\n"
+            "feature_columns = ['distance_m']\n"
+            "feature_transforms = ['identity']\n"
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="dataset-only and has no model parity path"):
+        load_market_feature_comparison_config(config_path)
+
+
+def test_load_market_feature_comparison_config_rejects_feature_set_mismatch(tmp_path: Path) -> None:
+    config_path = tmp_path / "comparison_mismatch.toml"
+    config_path.write_text(
+        (
+            "[comparison]\n"
+            "name = 'comparison_mismatch'\n"
+            "duckdb_path = 'data/artifacts/jrdb.duckdb'\n"
+            "output_dir = 'data/artifacts/out'\n"
+            "start_date = '2025-01-01'\n"
+            "end_date = '2025-12-31'\n"
+            "target_name = 'is_place'\n"
+            "backtest_template_config_path = 'configs/place_backtest_odds_log1p_plus_popularity.toml'\n"
+            "aggregate_selection_score_rule = 'mean_valid_roi'\n"
+            "\n"
+            "[[comparison.feature_sets]]\n"
+            "name = 'dual_market_bad_order'\n"
+            "dataset_feature_set = 'dual_market'\n"
+            "model_name = 'logistic_regression'\n"
+            "feature_columns = ['win_odds', 'popularity']\n"
+            "feature_transforms = ['log1p', 'identity']\n"
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="must match dataset_feature_set 'dual_market'"):
+        load_market_feature_comparison_config(config_path)
+
+
+def test_load_place_backtest_config_rejects_dataset_only_rolling_feature(tmp_path: Path) -> None:
+    config_path = tmp_path / "backtest_invalid.toml"
+    config_path.write_text(
+        (
+            "[backtest]\n"
+            "name = 'backtest_invalid'\n"
+            "predictions_path = 'data/artifacts/predictions.csv'\n"
+            "duckdb_path = 'data/artifacts/jrdb.duckdb'\n"
+            "output_dir = 'data/artifacts/out'\n"
+            "threshold = 0.5\n"
+            "\n"
+            "[rolling_retrain]\n"
+            "dataset_path = 'data/processed/dataset.parquet'\n"
+            "feature_columns = ['race_name']\n"
+            "feature_transforms = ['identity']\n"
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="features not allowed in model parity path"):
+        load_place_backtest_config(config_path)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import duckdb
@@ -12,7 +13,12 @@ from horse_bet_lab.dataset.service import (
     build_horse_dataset,
     processed_columns,
 )
-from horse_bet_lab.ingest.service import ingest_jrdb_directory
+from horse_bet_lab.ingest.service import (
+    create_pre_race_market_tables,
+    create_win_market_snapshot_view,
+    ingest_jrdb_directory,
+    refresh_pre_race_market_staging,
+)
 
 BAC_SAMPLE_LINE_1 = bytes.fromhex(
     "3035323531383031323032353032323331303035313430303232313132413331303233208140814081408140814081408140814081408140814081408140814081408140814081408140814081408140814081408140202020202020202031362031814081408140814082528dce96a28f9f9798814081408140814034303035363030303232303030313430303030383430303035363030343030303030303031313131313131312020202020202020202020202020",
@@ -49,6 +55,8 @@ def test_build_horse_dataset_creates_expected_columns_and_grain(tmp_path: Path) 
     summary = build_horse_dataset(config)
 
     assert summary.row_count == 2
+    provenance_path = summary.output_path.with_name(f"{summary.output_path.name}.provenance.json")
+    assert provenance_path.exists()
 
     connection = duckdb.connect()
     try:
@@ -79,6 +87,16 @@ def test_build_horse_dataset_creates_expected_columns_and_grain(tmp_path: Path) 
     finally:
         connection.close()
 
+    payload = json.loads(provenance_path.read_text(encoding="utf-8"))
+    assert payload["feature_contract_version"] == "v1"
+    assert payload["dataset_feature_set"] == "minimal"
+    assert payload["dataset_feature_columns"] == [
+        "distance_m",
+        "race_name",
+        "workout_weekday",
+        "workout_date",
+    ]
+
 
 def test_build_horse_dataset_applies_period_filter(tmp_path: Path) -> None:
     duckdb_path = prepare_staging_database(tmp_path)
@@ -106,6 +124,7 @@ def test_build_horse_dataset_supports_market_plus_workout_minimal(tmp_path: Path
     duckdb_path = prepare_staging_database(tmp_path)
     result_path = tmp_path / "data" / "processed" / "dataset_market_workout.parquet"
     prepare_result_staging_database(duckdb_path)
+    prepare_oz_staging_database(duckdb_path)
 
     config_path = tmp_path / "dataset_market_workout.toml"
     config_path.write_text(
@@ -147,11 +166,72 @@ def test_build_horse_dataset_supports_market_plus_workout_minimal(tmp_path: Path
             [str(result_path)],
         ).fetchall()
         assert rows == [
-            ("05251801", 1, "valid", 12.3, 2, 4, 2, 1),
-            ("05251801", 2, "valid", 45.6, 8, 4, 2, 0),
+            ("05251801", 1, "valid", 11.2, 2, 4, 2, 1),
+            ("05251801", 2, "valid", 40.0, 8, 4, 2, 0),
         ]
     finally:
         connection.close()
+
+
+def test_build_horse_dataset_uses_win_market_snapshot_for_win_odds_and_legacy_sed_for_popularity(
+    tmp_path: Path,
+) -> None:
+    duckdb_path = prepare_staging_database(tmp_path)
+    prepare_result_staging_database(duckdb_path)
+    prepare_oz_staging_database(duckdb_path)
+    result_path = tmp_path / "data" / "processed" / "dataset_win_market_contract.parquet"
+
+    config_path = tmp_path / "dataset_win_market_contract.toml"
+    config_path.write_text(
+        (
+            "[dataset]\n"
+            "name = 'horse_dataset_win_market_contract'\n"
+            "start_date = '2025-02-01'\n"
+            "end_date = '2025-02-28'\n"
+            "feature_set = 'win_market_only'\n"
+            "target_name = 'is_place'\n"
+            f"duckdb_path = '{duckdb_path}'\n"
+            f"output_path = '{result_path}'\n"
+        ),
+        encoding="utf-8",
+    )
+
+    summary = build_horse_dataset(load_dataset_build_config(config_path))
+
+    assert summary.row_count == 2
+
+    connection = duckdb.connect()
+    try:
+        rows = connection.execute(
+            """
+            SELECT
+                race_key,
+                horse_number,
+                win_odds,
+                popularity,
+                target_value
+            FROM read_parquet(?)
+            ORDER BY horse_number
+            """,
+            [str(result_path)],
+        ).fetchall()
+        assert rows == [
+            ("05251801", 1, 11.2, 2, 1),
+            ("05251801", 2, 40.0, 8, 0),
+        ]
+    finally:
+        connection.close()
+
+    payload = json.loads(
+        result_path.with_name(f"{result_path.name}.provenance.json").read_text(encoding="utf-8"),
+    )
+    definitions = {row["canonical_name"]: row for row in payload["feature_definitions"]}
+    assert definitions["win_odds"]["carrier_identity"] == "win_market_snapshot_v1"
+    assert definitions["popularity"]["carrier_identity"] == "legacy_sed_only"
+    assert payload["feature_source_summary"]["by_carrier_identity"] == {
+        "legacy_sed_only": 1,
+        "win_market_snapshot_v1": 1,
+    }
 
 
 def test_build_horse_dataset_supports_dual_market_features(tmp_path: Path) -> None:
@@ -196,8 +276,8 @@ def test_build_horse_dataset_supports_dual_market_features(tmp_path: Path) -> No
             [str(result_path)],
         ).fetchall()
         assert rows == [
-            ("05251801", 1, 12.3, 2.4, 2, 1),
-            ("05251801", 2, 45.6, 3.1, 8, 0),
+            ("05251801", 1, 11.2, 2.4, 2, 1),
+            ("05251801", 2, 40.0, 3.1, 8, 0),
         ]
     finally:
         connection.close()
@@ -264,8 +344,8 @@ def test_build_horse_dataset_supports_single_win_market_feature_sets(tmp_path: P
             [str(win_market_path)],
         ).fetchall()
         assert win_market_rows == [
-            ("05251801", 1, 12.3, 2, 1),
-            ("05251801", 2, 45.6, 8, 0),
+            ("05251801", 1, 11.2, 2, 1),
+            ("05251801", 2, 40.0, 8, 0),
         ]
 
         dual_market_rows = connection.execute(
@@ -277,8 +357,8 @@ def test_build_horse_dataset_supports_single_win_market_feature_sets(tmp_path: P
             [str(dual_market_path)],
         ).fetchall()
         assert dual_market_rows == [
-            ("05251801", 1, 12.3, 2.4, 2, 1),
-            ("05251801", 2, 45.6, 3.1, 8, 0),
+            ("05251801", 1, 11.2, 2.4, 2, 1),
+            ("05251801", 2, 40.0, 3.1, 8, 0),
         ]
     finally:
         connection.close()
@@ -327,8 +407,8 @@ def test_build_horse_dataset_supports_dual_market_derived_features(tmp_path: Pat
             [str(result_path)],
         ).fetchall()
         assert rows == [
-            ("05251801", 1, 12.3, 2.4, 2, -1.634131, 1),
-            ("05251801", 2, 45.6, 3.1, 8, -2.688506, 0),
+            ("05251801", 1, 11.2, 2.4, 2, -1.540445, 1),
+            ("05251801", 2, 40.0, 3.1, 8, -2.557477, 0),
         ]
     finally:
         connection.close()
@@ -379,8 +459,8 @@ def test_build_horse_dataset_supports_dual_market_headcount_features(tmp_path: P
             [str(result_path)],
         ).fetchall()
         assert rows == [
-            ("05251801", 1, 12.3, 2.4, 2, 2, 2, 1400, 1),
-            ("05251801", 2, 45.6, 3.1, 8, 2, 2, 1400, 0),
+            ("05251801", 1, 11.2, 2.4, 2, 2, 2, 1400, 1),
+            ("05251801", 2, 40.0, 3.1, 8, 2, 2, 1400, 0),
         ]
     finally:
         connection.close()
@@ -424,6 +504,25 @@ def test_build_horse_dataset_supports_odds_only_from_sed_without_bac_cha(tmp_pat
                 (
                     '01240201', 1, 'r3', DATE '2024-02-10', 'horse3',
                     1400, 3, '6.1', 1, 'sample', 'hash', 1, NOW()
+                )
+            """,
+        )
+        create_pre_race_market_tables(connection)
+        create_win_market_snapshot_view(connection)
+        connection.execute(
+            """
+            INSERT INTO jrdb_pre_race_market_staging VALUES
+                (
+                    '01240101', 1, 8.5, 'oz_win_basis_odds', DATE '2024-01-06',
+                    'jrdb_oz_staging', 'win_basis_odds', 'sample', 'hash', 1, NOW()
+                ),
+                (
+                    '01240101', 2, 15.2, 'oz_win_basis_odds', DATE '2024-01-06',
+                    'jrdb_oz_staging', 'win_basis_odds', 'sample', 'hash', 1, NOW()
+                ),
+                (
+                    '01240201', 1, 6.1, 'oz_win_basis_odds', DATE '2024-02-10',
+                    'jrdb_oz_staging', 'win_basis_odds', 'sample', 'hash', 1, NOW()
                 )
             """,
         )
@@ -662,6 +761,7 @@ def prepare_oz_staging_database(duckdb_path: Path) -> None:
                 ('05251801', 2, 2, 40.0, 3.1, 'sample', 'hash', 1, NOW())
             """,
         )
+        refresh_pre_race_market_staging(connection)
     finally:
         connection.close()
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -41,8 +41,12 @@ def test_train_logistic_regression_baseline_writes_metrics_and_predictions(
     assert metrics_path.exists()
     assert predictions_path.exists()
     assert calibration_path.exists()
+    assert (predictions_path.with_name(f"{predictions_path.name}.provenance.json")).exists()
+    assert (calibration_path.with_name(f"{calibration_path.name}.provenance.json")).exists()
 
     metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+    assert metrics["provenance"]["feature_contract_version"] == "v1"
+    assert metrics["provenance"]["model_feature_columns"] == ["win_odds"]
     assert metrics["training"]["feature_columns"] == ["win_odds"]
     assert metrics["training"]["feature_transforms"] == ["identity"]
     assert set(metrics["metrics"]) == {"train", "valid", "test"}

--- a/tests/test_place_backtest.py
+++ b/tests/test_place_backtest.py
@@ -47,6 +47,7 @@ def test_run_place_backtest_writes_summary_artifacts(tmp_path: Path) -> None:
 
     assert (result.output_dir / "summary.csv").exists()
     assert (result.output_dir / "summary.json").exists()
+    assert (result.output_dir / "feature_provenance.json").exists()
     assert (result.output_dir / "candidate_summary.csv").exists()
     assert (result.output_dir / "candidate_summary.json").exists()
     assert (result.output_dir / "uncertainty_summary.csv").exists()
@@ -58,6 +59,7 @@ def test_run_place_backtest_writes_summary_artifacts(tmp_path: Path) -> None:
     assert (result.output_dir / "monthly_place_basis_buckets.csv").exists()
 
     payload = json.loads((result.output_dir / "summary.json").read_text(encoding="utf-8"))
+    assert payload["provenance"]["feature_contract_version"] == "v1"
     assert payload["backtest"]["selection_metric"] == "probability"
     assert payload["backtest"]["thresholds"] == [0.5, 0.75]
     assert len(payload["summaries"]) == 6

--- a/tests/test_proxy_live_inference.py
+++ b/tests/test_proxy_live_inference.py
@@ -174,6 +174,12 @@ def test_proxy_live_pipeline_writes_manifest_and_gap_summary(tmp_path: Path) -> 
     assert manifest["source_url"] == "https://example.com/odds"
     assert manifest["source_timestamp"] == "2026-04-19T08:00:00+09:00"
     assert manifest["input_csv_hash"] == hashlib.sha256(input_path.read_bytes()).hexdigest()
+    assert manifest["provenance"]["feature_contract_version"] == "v1"
+    assert manifest["provenance"]["model_feature_columns"] == [
+        "win_odds",
+        "place_basis_odds",
+        "popularity",
+    ]
 
     gap_summary = json.loads(
         (output_path.parent / "proxy_feature_gap_summary.json").read_text(encoding="utf-8")
@@ -217,3 +223,51 @@ def test_proxy_live_rejects_forbidden_leakage_columns(tmp_path: Path) -> None:
         assert "forbidden leakage columns" in str(exc)
     else:
         raise AssertionError("expected leakage columns to be rejected")
+
+
+def test_proxy_live_config_rejects_dataset_only_feature_columns(tmp_path: Path) -> None:
+    module = load_proxy_live_module()
+
+    dataset_path = tmp_path / "dataset.parquet"
+    input_path = tmp_path / "input.csv"
+    output_path = tmp_path / "artifacts" / "scores.csv"
+    config_path = tmp_path / "config_invalid.toml"
+    db_path = tmp_path / "historical.duckdb"
+
+    create_training_dataset(dataset_path)
+    create_historical_duckdb(db_path)
+    write_live_input(input_path)
+    config_path.write_text(
+        (
+            "[live_inference]\n"
+            "name = 'proxy_live_invalid'\n"
+            "race_name = 'Test Race'\n"
+            "race_date = '2026-04-19'\n"
+            f"input_path = '{input_path}'\n"
+            f"output_path = '{output_path}'\n"
+            "input_source = 'Public odds page'\n"
+            "source_url = 'https://example.com/odds'\n"
+            "source_timestamp = '2026-04-19T08:00:00+09:00'\n"
+            "proxy_rule = 'place_basis_odds_proxy = (place_odds_min + place_odds_max) / 2'\n"
+            "\n"
+            "[live_inference.reference_model]\n"
+            f"dataset_path = '{dataset_path}'\n"
+            f"historical_duckdb_path = '{db_path}'\n"
+            "model_name = 'logistic_regression'\n"
+            "feature_columns = ['win_odds', 'race_name']\n"
+            "feature_transforms = ['log1p', 'identity']\n"
+            "target_column = 'target_value'\n"
+            "split_column = 'split'\n"
+            "training_splits = ['train', 'valid', 'test']\n"
+            "max_iter = 200\n"
+            "model_params = {}\n"
+        ),
+        encoding="utf-8",
+    )
+
+    try:
+        module.load_config(config_path)
+    except ValueError as exc:
+        assert "features not allowed in model parity path" in str(exc)
+    else:
+        raise AssertionError("expected dataset-only live feature config to be rejected")


### PR DESCRIPTION
## Summary
- formalize feature contract v1 through a registry-backed source of truth
- add config-time validation for dataset feature sets and model feature columns
- enforce parity-safe model feature selection and reject dataset-only / non-numeric / forbidden features in model paths
- add feature provenance wiring across dataset, model, and backtest artifacts
- preserve current baseline, BET logic, and frozen win_odds migration decisions

## Included commits
- `60055c7a37757ecdb3620576928d019daed897cb` — `formalize feature contract v1 registry and config validation`
- `17b3efb11fb96fad7ddc07cd9da869be7e69042f` — `add feature provenance wiring across dataset model and backtest artifacts`

## Scope
### Registry / validation
- `docs/spec/feature_contract_v1.md`
- `src/horse_bet_lab/features/__init__.py`
- `src/horse_bet_lab/features/registry.py`
- `src/horse_bet_lab/features/provenance.py`
- `src/horse_bet_lab/config.py`
- `scripts/live_inference_score.py`
- `tests/test_config.py`
- `tests/test_proxy_live_inference.py`

### Provenance wiring
- `src/horse_bet_lab/dataset/service.py`
- `src/horse_bet_lab/model/service.py`
- `src/horse_bet_lab/evaluation/place_backtest.py`
- `tests/test_dataset.py`
- `tests/test_model.py`
- `tests/test_place_backtest.py`

## Validation
- `PYTHONPATH=src .venv/bin/python -m pytest tests/test_config.py tests/test_proxy_live_inference.py tests/test_dataset.py tests/test_model.py tests/test_place_backtest.py`
- Result: `36 passed, 1 warning`
- Environment: `.venv` Python `3.11.15`, pytest `9.0.3`

## Non-goals
- no BET logic changes
- no baseline rewrite
- no win_odds carrier migration retry
- no popularity carrier resolution
- no unrelated mixed diff cleanup

## Follow-up items kept out of this PR
- popularity true pre-race carrier confirmation
- missing/null policy finalization
- live proxy alias management expansion
- mixed worktree diffs unrelated to feature contract v1