### PR TITLE
add recurring operator rehearsal execution for place forward test phase 1

### DIFF
--- a/configs/recurring_rehearsal/20250420_satsuki_sho.bridge.toml
+++ b/configs/recurring_rehearsal/20250420_satsuki_sho.bridge.toml
@@ -1,0 +1,28 @@
+[place_forward_snapshot_bridge]
+name = "place_forward_snapshot_bridge_runtime_20250420_satsuki_sho"
+output_path = "data/forward_test/runs/20250420_satsuki_sho/contract/input_snapshot_20250420_satsuki_sho.csv"
+strict_race_key = true
+infer_snapshot_status = true
+write_json_copy = true
+
+[place_forward_snapshot_bridge.columns]
+race_key = "race_key"
+horse_number = "horse_number"
+win_odds = "win_odds"
+place_basis_odds_proxy = "place_basis_odds_proxy"
+popularity = "popularity"
+snapshot_status = "snapshot_status"
+retry_count = "retry_count"
+timeout_seconds = "timeout_seconds"
+snapshot_failure_reason = "snapshot_failure_reason"
+
+[[place_forward_snapshot_bridge.sources]]
+path = "data/forward_test/runs/20250420_satsuki_sho/raw/input_snapshot_raw.csv"
+input_source_name = "keibalab_public_pre_race_odds"
+input_source_url = "https://www.keibalab.jp/db/race/202504200611/odds.html"
+input_source_timestamp = "2025-04-20T15:48:00+09:00"
+odds_observation_timestamp = "2025-04-20T15:48:00+09:00"
+carrier_identity = "place_forward_live_snapshot_v1"
+default_retry_count = 1
+default_timeout_seconds = 15
+default_popularity_input_source = "keibalab_public_pre_race_odds"

--- a/configs/recurring_rehearsal/20250420_satsuki_sho.pre_race.toml
+++ b/configs/recurring_rehearsal/20250420_satsuki_sho.pre_race.toml
@@ -1,0 +1,28 @@
+[place_forward_test]
+name = "place_forward_test_phase1_20250420_satsuki_sho"
+input_path = "data/forward_test/runs/20250420_satsuki_sho/contract/input_snapshot_20250420_satsuki_sho.csv"
+output_dir = "data/artifacts/place_forward_test/20250420_satsuki_sho/pre_race"
+input_schema_version = "place_forward_test_input_v1"
+
+[place_forward_test.reference_model]
+dataset_path = "data/processed/horse_dataset_odds_only_is_place.parquet"
+model_name = "logistic_regression"
+feature_columns = ["win_odds"]
+feature_transforms = ["identity"]
+target_column = "target_value"
+split_column = "split"
+training_splits = ["train", "valid", "test"]
+max_iter = 1000
+model_version = "odds_only_logreg_is_place@recurring_rehearsal_20250420_satsuki_sho"
+
+[place_forward_test.reference_model.model_params]
+random_state = 42
+
+[place_forward_test.bet_logic]
+selection_metric = "edge"
+threshold = 0.08
+stake_per_bet = 100.0
+stronger_guard_edge_surcharge = 0.01
+candidate_logic_id = "guard_0_01_plus_proxy_domain_overlay"
+fallback_logic_id = "no_bet_guard_stronger"
+formal_domain_mapping_confirmed = true

--- a/configs/recurring_rehearsal/20250420_satsuki_sho.reconciliation.toml
+++ b/configs/recurring_rehearsal/20250420_satsuki_sho.reconciliation.toml
@@ -1,0 +1,6 @@
+[place_forward_reconciliation]
+name = "place_forward_test_reconciliation_20250420_satsuki_sho"
+forward_output_dir = "data/artifacts/place_forward_test/20250420_satsuki_sho/pre_race"
+duckdb_path = "data/artifacts/jrdb_2023_2025_supported_full.duckdb"
+output_dir = "data/artifacts/place_forward_test/20250420_satsuki_sho/reconciliation"
+settled_as_of = "2025-04-20T18:00:00+09:00"

--- a/configs/recurring_rehearsal/20260419_failure_probe.bridge.toml
+++ b/configs/recurring_rehearsal/20260419_failure_probe.bridge.toml
@@ -1,0 +1,28 @@
+[place_forward_snapshot_bridge]
+name = "place_forward_snapshot_bridge_runtime_20260419_failure_probe"
+output_path = "data/forward_test/runs/20260419_failure_probe/contract/input_snapshot_20260419_failure_probe.csv"
+strict_race_key = true
+infer_snapshot_status = true
+write_json_copy = true
+
+[place_forward_snapshot_bridge.columns]
+race_key = "race_key"
+horse_number = "horse_number"
+win_odds = "win_odds"
+place_basis_odds_proxy = "place_basis_odds_proxy"
+popularity = "popularity"
+snapshot_status = "snapshot_status"
+retry_count = "retry_count"
+timeout_seconds = "timeout_seconds"
+snapshot_failure_reason = "snapshot_failure_reason"
+
+[[place_forward_snapshot_bridge.sources]]
+path = "data/forward_test/runs/20260419_failure_probe/raw/input_snapshot_raw.csv"
+input_source_name = "operator_manual_failure_probe"
+input_source_url = "https://example.invalid/manual-failure-probe"
+input_source_timestamp = "2026-04-19T07:55:00+09:00"
+odds_observation_timestamp = "2026-04-19T07:55:00+09:00"
+carrier_identity = "place_forward_live_snapshot_v1"
+default_retry_count = 3
+default_timeout_seconds = 15
+default_popularity_input_source = "operator_manual_failure_probe"

--- a/configs/recurring_rehearsal/20260419_failure_probe.pre_race.toml
+++ b/configs/recurring_rehearsal/20260419_failure_probe.pre_race.toml
@@ -1,0 +1,28 @@
+[place_forward_test]
+name = "place_forward_test_phase1_20260419_failure_probe"
+input_path = "data/forward_test/runs/20260419_failure_probe/contract/input_snapshot_20260419_failure_probe.csv"
+output_dir = "data/artifacts/place_forward_test/20260419_failure_probe/pre_race"
+input_schema_version = "place_forward_test_input_v1"
+
+[place_forward_test.reference_model]
+dataset_path = "data/processed/horse_dataset_odds_only_is_place.parquet"
+model_name = "logistic_regression"
+feature_columns = ["win_odds"]
+feature_transforms = ["identity"]
+target_column = "target_value"
+split_column = "split"
+training_splits = ["train", "valid", "test"]
+max_iter = 1000
+model_version = "odds_only_logreg_is_place@recurring_rehearsal_20260419_failure_probe"
+
+[place_forward_test.reference_model.model_params]
+random_state = 42
+
+[place_forward_test.bet_logic]
+selection_metric = "edge"
+threshold = 0.08
+stake_per_bet = 100.0
+stronger_guard_edge_surcharge = 0.01
+candidate_logic_id = "guard_0_01_plus_proxy_domain_overlay"
+fallback_logic_id = "no_bet_guard_stronger"
+formal_domain_mapping_confirmed = true

--- a/configs/recurring_rehearsal/20260419_failure_probe.reconciliation.toml
+++ b/configs/recurring_rehearsal/20260419_failure_probe.reconciliation.toml
@@ -1,0 +1,6 @@
+[place_forward_reconciliation]
+name = "place_forward_test_reconciliation_20260419_failure_probe"
+forward_output_dir = "data/artifacts/place_forward_test/20260419_failure_probe/pre_race"
+duckdb_path = "data/artifacts/jrdb_2023_2025_supported_full.duckdb"
+output_dir = "data/artifacts/place_forward_test/20260419_failure_probe/reconciliation"
+settled_as_of = "2026-04-20T18:00:00+09:00"

--- a/configs/recurring_rehearsal/20260419_satsuki_sho.bridge.toml
+++ b/configs/recurring_rehearsal/20260419_satsuki_sho.bridge.toml
@@ -1,0 +1,28 @@
+[place_forward_snapshot_bridge]
+name = "place_forward_snapshot_bridge_runtime_20260419_satsuki_sho"
+output_path = "data/forward_test/runs/20260419_satsuki_sho/contract/input_snapshot_20260419_satsuki_sho.csv"
+strict_race_key = true
+infer_snapshot_status = true
+write_json_copy = true
+
+[place_forward_snapshot_bridge.columns]
+race_key = "race_key"
+horse_number = "horse_number"
+win_odds = "win_odds"
+place_basis_odds_proxy = "place_basis_odds_proxy"
+popularity = "popularity"
+snapshot_status = "snapshot_status"
+retry_count = "retry_count"
+timeout_seconds = "timeout_seconds"
+snapshot_failure_reason = "snapshot_failure_reason"
+
+[[place_forward_snapshot_bridge.sources]]
+path = "data/forward_test/runs/20260419_satsuki_sho/raw/input_snapshot_raw.csv"
+input_source_name = "keibalab_public_pre_race_odds"
+input_source_url = "https://www.keibalab.jp/db/race/202604190611/odds.html"
+input_source_timestamp = "2026-04-18T07:50:00+09:00"
+odds_observation_timestamp = "2026-04-18T07:50:00+09:00"
+carrier_identity = "place_forward_live_snapshot_v1"
+default_retry_count = 1
+default_timeout_seconds = 15
+default_popularity_input_source = "keibalab_public_pre_race_odds"

--- a/configs/recurring_rehearsal/20260419_satsuki_sho.pre_race.toml
+++ b/configs/recurring_rehearsal/20260419_satsuki_sho.pre_race.toml
@@ -1,0 +1,28 @@
+[place_forward_test]
+name = "place_forward_test_phase1_20260419_satsuki_sho"
+input_path = "data/forward_test/runs/20260419_satsuki_sho/contract/input_snapshot_20260419_satsuki_sho.csv"
+output_dir = "data/artifacts/place_forward_test/20260419_satsuki_sho/pre_race"
+input_schema_version = "place_forward_test_input_v1"
+
+[place_forward_test.reference_model]
+dataset_path = "data/processed/horse_dataset_odds_only_is_place.parquet"
+model_name = "logistic_regression"
+feature_columns = ["win_odds"]
+feature_transforms = ["identity"]
+target_column = "target_value"
+split_column = "split"
+training_splits = ["train", "valid", "test"]
+max_iter = 1000
+model_version = "odds_only_logreg_is_place@recurring_rehearsal_20260419_satsuki_sho"
+
+[place_forward_test.reference_model.model_params]
+random_state = 42
+
+[place_forward_test.bet_logic]
+selection_metric = "edge"
+threshold = 0.08
+stake_per_bet = 100.0
+stronger_guard_edge_surcharge = 0.01
+candidate_logic_id = "guard_0_01_plus_proxy_domain_overlay"
+fallback_logic_id = "no_bet_guard_stronger"
+formal_domain_mapping_confirmed = true

--- a/configs/recurring_rehearsal/20260419_satsuki_sho.reconciliation.toml
+++ b/configs/recurring_rehearsal/20260419_satsuki_sho.reconciliation.toml
@@ -1,0 +1,6 @@
+[place_forward_reconciliation]
+name = "place_forward_test_reconciliation_20260419_satsuki_sho"
+forward_output_dir = "data/artifacts/place_forward_test/20260419_satsuki_sho/pre_race"
+duckdb_path = "data/artifacts/jrdb_2023_2025_supported_full.duckdb"
+output_dir = "data/artifacts/place_forward_test/20260419_satsuki_sho/reconciliation"
+settled_as_of = "2026-04-20T18:00:00+09:00"

--- a/configs/templates/place_forward_snapshot_bridge_runtime.template.toml
+++ b/configs/templates/place_forward_snapshot_bridge_runtime.template.toml
@@ -1,0 +1,31 @@
+# Runtime template for recurring place-only forward-test snapshot bridge runs.
+# Copy this file per rehearsal unit and replace placeholder values.
+
+[place_forward_snapshot_bridge]
+name = "place_forward_snapshot_bridge_runtime_<unit_id>"
+output_path = "data/forward_test/runs/<unit_id>/contract/input_snapshot_<unit_id>.csv"
+strict_race_key = true
+infer_snapshot_status = true
+write_json_copy = true
+
+[place_forward_snapshot_bridge.columns]
+race_key = "race_key"
+horse_number = "horse_number"
+win_odds = "win_odds"
+place_basis_odds_proxy = "place_basis_odds_proxy"
+popularity = "popularity"
+snapshot_status = "snapshot_status"
+retry_count = "retry_count"
+timeout_seconds = "timeout_seconds"
+snapshot_failure_reason = "snapshot_failure_reason"
+
+[[place_forward_snapshot_bridge.sources]]
+path = "data/forward_test/runs/<unit_id>/raw/input_snapshot_raw.csv"
+input_source_name = "replace_with_source_name"
+input_source_url = "https://replace.example/source"
+input_source_timestamp = "2026-04-20T15:30:00+09:00"
+odds_observation_timestamp = "2026-04-20T15:30:00+09:00"
+carrier_identity = "place_forward_live_snapshot_v1"
+default_retry_count = 1
+default_timeout_seconds = 15
+default_popularity_input_source = "replace_with_popularity_source_or_leave_same_as_source"

--- a/configs/templates/place_forward_test_phase1_runtime.template.toml
+++ b/configs/templates/place_forward_test_phase1_runtime.template.toml
@@ -1,0 +1,31 @@
+# Runtime template for recurring place-only forward-test Phase 1 pre-race runs.
+# Copy this file per rehearsal unit and replace placeholder values.
+
+[place_forward_test]
+name = "place_forward_test_phase1_<unit_id>"
+input_path = "data/forward_test/runs/<unit_id>/contract/input_snapshot_<unit_id>.csv"
+output_dir = "data/artifacts/place_forward_test/<unit_id>/pre_race"
+input_schema_version = "place_forward_test_input_v1"
+
+[place_forward_test.reference_model]
+dataset_path = "data/processed/dataset_is_place/dataset.parquet"
+model_name = "logreg"
+feature_columns = ["win_odds"]
+feature_transforms = []
+target_column = "target_value"
+split_column = "split"
+training_splits = ["train", "valid", "test"]
+max_iter = 1000
+model_version = "replace_with_mainline_model_version"
+
+[place_forward_test.reference_model.model_params]
+random_state = 42
+
+[place_forward_test.bet_logic]
+selection_metric = "edge"
+threshold = 0.08
+stake_per_bet = 100.0
+stronger_guard_edge_surcharge = 0.01
+candidate_logic_id = "guard_0_01_plus_proxy_domain_overlay"
+fallback_logic_id = "no_bet_guard_stronger"
+formal_domain_mapping_confirmed = true

--- a/configs/templates/place_forward_test_reconciliation_runtime.template.toml
+++ b/configs/templates/place_forward_test_reconciliation_runtime.template.toml
@@ -1,0 +1,9 @@
+# Runtime template for recurring place-only forward-test reconciliation runs.
+# Copy this file per rehearsal unit and replace placeholder values.
+
+[place_forward_reconciliation]
+name = "place_forward_test_reconciliation_<unit_id>"
+forward_output_dir = "data/artifacts/place_forward_test/<unit_id>/pre_race"
+duckdb_path = "data/artifacts/jrdb_2023_2025_supported_full.duckdb"
+output_dir = "data/artifacts/place_forward_test/<unit_id>/reconciliation"
+settled_as_of = "2026-04-20T18:00:00+09:00"

--- a/docs/checkpoints/place_forward_test_recurring_weekly_review_2026W17.md
+++ b/docs/checkpoints/place_forward_test_recurring_weekly_review_2026W17.md
@@ -1,0 +1,48 @@
+# Place Forward-Test Recurring Weekly Review 2026W17
+
+## Run units reviewed
+
+- `20250420_satsuki_sho`
+- `20260419_satsuki_sho`
+- `20260419_failure_probe`
+
+## Per-unit summary
+
+### 20250420_satsuki_sho
+
+- bridge: `ok=18`
+- pre-race: `bets=2`, `no_bet=16`
+- no-bet reasons: `logic_filtered=16`
+- reconciliation: `settled_hit=1`, `settled_miss=1`, `settled_no_bet=16`
+- result: fully settled
+
+### 20260419_satsuki_sho
+
+- bridge: `ok=18`
+- pre-race: `bets=4`, `no_bet=14`
+- no-bet reasons: `logic_filtered=14`
+- reconciliation: `unsettled_result_pending=18`
+- result: operationally successful, but result DB side still pending
+
+### 20260419_failure_probe
+
+- bridge: `timeout=1`, `required_odds_missing=1`
+- pre-race: `bets=0`, `no_bet=2`
+- no-bet reasons: `timeout=1`, `required_odds_missing=1`
+- reconciliation: `unsettled_result_pending=2`
+- result: failure-state path behaved as expected
+
+## Operator pain points found
+
+- raw snapshot acquisition is still manual before the bridge step
+- recurring cadence is understandable, but each unit still requires three small runtime configs
+- result DB availability is the main source of ambiguity after race day
+  - a unit can be procedurally complete while remaining fully `unsettled_result_pending`
+- weekly review needs one place where settled units and pending units are separated immediately
+
+## Conclusion
+
+- recurring cadence is usable as an operator rehearsal path
+- naming convention and directory layout did not break across multiple run units
+- snapshot failure states and logic-filter states remained readable
+- the next practical improvement is to keep repeating the weekly cadence and reduce manual overhead around raw snapshot acquisition and result DB confirmation

--- a/docs/runbooks/place_forward_test_phase1_recurring_rehearsal.md
+++ b/docs/runbooks/place_forward_test_phase1_recurring_rehearsal.md
@@ -29,6 +29,7 @@
 - その週の run units をざっと見直す
 - `logic_filtered` と snapshot failure 系 reason の比率を確認する
 - settled / unsettled の残りを確認し、必要なら archive note を残す
+- result DB 未更新による `unsettled_result_pending` と operator 側の手順ミスを混同しない
 
 ## Recommended Directory And Naming Convention
 
@@ -105,6 +106,8 @@ data/forward_test/runs/<unit_id>/notes/
 3. `logic_filtered` が極端に偏っていないか確認する
 4. unsettled のまま残っている unit を確認する
 5. 次週も同じ命名規則と template で回せるか確認する
+
+週次メモを残すときの雛形は [docs/runbooks/place_forward_test_phase1_weekly_review_template.md](/Users/matsurimbpblack/Library/Mobile%20Documents/com~apple~CloudDocs/codex_projects/horse-bet-lab/docs/runbooks/place_forward_test_phase1_weekly_review_template.md:1) を使う。
 
 ## Artifact Reading Guide
 

--- a/docs/runbooks/place_forward_test_phase1_recurring_rehearsal.md
+++ b/docs/runbooks/place_forward_test_phase1_recurring_rehearsal.md
@@ -1,0 +1,151 @@
+# Place Forward-Test Phase 1 Recurring Rehearsal
+
+## Purpose
+
+この文書は、place-only forward-test Phase 1 を単発 example ではなく、同じ手順で繰り返し回せる最小運用リハーサルとして固定するための cadence / checklist / naming rule をまとめるものです。
+
+対象は current mainline baseline の複勝一本 path です。
+
+- current candidate: `guard_0_01_plus_proxy_domain_overlay`
+- status: `hard_adopt`
+- fallback: `no_bet_guard_stronger surcharge=0.01`
+
+## Recurring Cadence
+
+### Race day pre-race run
+
+- raw/live-ish snapshot を当日分として収集する
+- bridge で contract CSV に変換する
+- pre-race runner を回して prediction / decision artifact を保存する
+
+### Result-confirmed post-race reconciliation
+
+- result DB が更新済みかを確認する
+- reconciliation を回して settled / unsettled を確定する
+- 当日の run と reconciliation artifact を同じ rehearsal unit として残す
+
+### Weekly review / archive
+
+- その週の run units をざっと見直す
+- `logic_filtered` と snapshot failure 系 reason の比率を確認する
+- settled / unsettled の残りを確認し、必要なら archive note を残す
+
+## Recommended Directory And Naming Convention
+
+rehearsal unit は `YYYYMMDD_meeting_slug` を基本単位にする。
+
+例:
+
+- unit id: `20250420_satsuki_sho`
+
+推奨配置:
+
+```text
+data/forward_test/runs/<unit_id>/raw/
+data/forward_test/runs/<unit_id>/contract/
+data/artifacts/place_forward_test/<unit_id>/pre_race/
+data/artifacts/place_forward_test/<unit_id>/reconciliation/
+data/forward_test/runs/<unit_id>/notes/
+```
+
+役割:
+
+- `raw/`
+  - live-ish snapshot input を置く
+- `contract/`
+  - bridge で生成した contract CSV / JSON / manifest を置く
+- `pre_race/`
+  - runner output を置く
+- `reconciliation/`
+  - reconciliation output を置く
+- `notes/`
+  - operator memo や週次メモを置く
+
+命名原則:
+
+- bridge output:
+  - `input_snapshot_<unit_id>.csv`
+  - `input_snapshot_<unit_id>.json`
+  - `input_snapshot_<unit_id>.manifest.json`
+  - `input_snapshot_<unit_id>.summary.txt`
+- pre-race output dir:
+  - `data/artifacts/place_forward_test/<unit_id>/pre_race`
+- reconciliation output dir:
+  - `data/artifacts/place_forward_test/<unit_id>/reconciliation`
+- optional note:
+  - `data/forward_test/runs/<unit_id>/notes/operator_note.md`
+
+## Checklist
+
+### Pre-race checklist
+
+1. 今日の rehearsal unit id を決める
+2. raw snapshot CSV を `raw/` に置く
+3. `configs/templates/place_forward_snapshot_bridge_runtime.template.toml` をコピーして source path と metadata を埋める
+4. bridge を実行する
+5. generated contract CSV と bridge manifest を確認する
+6. `configs/templates/place_forward_test_phase1_runtime.template.toml` をコピーして `input_path` / `output_dir` / `dataset_path` / `model_version` を埋める
+7. current baseline の bet logic identifiers が変わっていないことを確認する
+8. pre-race runner を実行する
+9. `bet_decision_records.csv` と `run_manifest.json` を確認する
+
+### Post-race checklist
+
+1. result DB が対象開催まで更新済みかを確認する
+2. `configs/templates/place_forward_test_reconciliation_runtime.template.toml` をコピーして `forward_output_dir` / `duckdb_path` / `output_dir` / `settled_as_of` を埋める
+3. reconciliation を実行する
+4. `reconciled_records.csv` を確認する
+5. `reconciliation_summary.json` を確認する
+6. `settled_hit`, `settled_miss`, `settled_no_bet`, `unsettled_*` の件数を確認する
+
+### Weekly / periodic checklist
+
+1. その週の rehearsal units を列挙する
+2. snapshot failure 系 reason が増えていないか確認する
+3. `logic_filtered` が極端に偏っていないか確認する
+4. unsettled のまま残っている unit を確認する
+5. 次週も同じ命名規則と template で回せるか確認する
+
+## Artifact Reading Guide
+
+最初に見る場所:
+
+- bridge 成功確認:
+  - `contract/input_snapshot_<unit_id>.summary.txt`
+  - `contract/input_snapshot_<unit_id>.manifest.json`
+- pre-race 判断確認:
+  - `pre_race/bet_decision_records.csv`
+  - `pre_race/run_manifest.json`
+- post-race 結果確認:
+  - `reconciliation/reconciled_records.csv`
+  - `reconciliation/reconciliation_summary.json`
+
+読み分けの最短ルール:
+
+- `logic_filtered`
+  - contract は通って prediction まで進んだが、BET logic 条件で `no_bet`
+- `timeout`, `required_odds_missing`, `snapshot_failure`, `retry_exhausted`
+  - snapshot failure 系の `no_bet`
+- `settled_hit`, `settled_miss`
+  - 当時 `bet` だった行の post-race outcome
+- `settled_no_bet`
+  - 結果は出たが当時は `no_bet`
+- `unsettled_result_pending`, `unsettled_result_incomplete`
+  - まだ結果確認が閉じていない
+
+## Template Files
+
+- bridge runtime template:
+  - [configs/templates/place_forward_snapshot_bridge_runtime.template.toml](/Users/matsurimbpblack/Library/Mobile%20Documents/com~apple~CloudDocs/codex_projects/horse-bet-lab/configs/templates/place_forward_snapshot_bridge_runtime.template.toml)
+- pre-race runtime template:
+  - [configs/templates/place_forward_test_phase1_runtime.template.toml](/Users/matsurimbpblack/Library/Mobile%20Documents/com~apple~CloudDocs/codex_projects/horse-bet-lab/configs/templates/place_forward_test_phase1_runtime.template.toml)
+- reconciliation runtime template:
+  - [configs/templates/place_forward_test_reconciliation_runtime.template.toml](/Users/matsurimbpblack/Library/Mobile%20Documents/com~apple~CloudDocs/codex_projects/horse-bet-lab/configs/templates/place_forward_test_reconciliation_runtime.template.toml)
+
+## Boundaries
+
+- BET logic は変えない
+- baseline は変えない
+- `popularity` は unresolved auxiliary のまま扱う
+- frozen `win_odds` migration は再開しない
+- 自動購入 / 外部連携は Phase 1 に含めない

--- a/docs/runbooks/place_forward_test_phase1_runbook.md
+++ b/docs/runbooks/place_forward_test_phase1_runbook.md
@@ -6,6 +6,8 @@
 
 対象は `horse_bet_lab.forward_test.runner` の Phase 1 path です。runner 本体のロジックはここでは変更しません。
 
+繰り返し運用の cadence / checklist / naming rule は [docs/runbooks/place_forward_test_phase1_recurring_rehearsal.md](/Users/matsurimbpblack/Library/Mobile%20Documents/com~apple~CloudDocs/codex_projects/horse-bet-lab/docs/runbooks/place_forward_test_phase1_recurring_rehearsal.md:1) を参照してください。
+
 ## Scope
 
 - 複勝一本

--- a/docs/runbooks/place_forward_test_phase1_weekly_review_template.md
+++ b/docs/runbooks/place_forward_test_phase1_weekly_review_template.md
@@ -1,0 +1,38 @@
+# Place Forward-Test Phase 1 Weekly Review Template
+
+## Week
+
+- week id:
+- review date:
+
+## Run units reviewed
+
+- `<unit_id>`
+
+## Per-unit status
+
+- settled units:
+- pending units:
+- snapshot failure probe units:
+
+## Key counts
+
+- total bets:
+- total no_bet:
+- settled hits:
+- settled misses:
+- settled no_bet:
+- unsettled result pending:
+
+## Operator pain points
+
+- raw snapshot acquisition:
+- config copy/edit burden:
+- result DB availability check:
+- artifact reading friction:
+
+## Follow-up for next week
+
+- checklist change needed or not:
+- naming convention change needed or not:
+- units to carry forward:


### PR DESCRIPTION
## Summary
- execute recurring operator rehearsal for the place-only forward-test Phase 1 workflow
- validate the recurring cadence across three run units
- confirm settled, unsettled, and snapshot-failure paths in actual rehearsal runs
- add a weekly review note and a weekly review template
- refine the recurring rehearsal runbook with operator guidance for pending-result interpretation
- keep current hard-adopt baseline, BET logic, and frozen carrier decisions unchanged

## Included commit
- `9caf6af` — `execute recurring operator rehearsal for place forward test phase 1`

## Scope
- recurring rehearsal runtime configs under `configs/recurring_rehearsal/`
- weekly review note and template
- recurring rehearsal runbook updates

## Run units exercised
- `20250420_satsuki_sho`
- `20260419_satsuki_sho`
- `20260419_failure_probe`

## Commands executed
- `PYTHONPATH=src .venv/bin/python -m horse_bet_lab.forward_test.snapshot_bridge_cli --config configs/recurring_rehearsal/20250420_satsuki_sho.bridge.toml`
- `PYTHONPATH=src .venv/bin/python -m horse_bet_lab.forward_test.cli --config configs/recurring_rehearsal/20250420_satsuki_sho.pre_race.toml`
- `PYTHONPATH=src .venv/bin/python -m horse_bet_lab.forward_test.reconciliation_cli --config configs/recurring_rehearsal/20250420_satsuki_sho.reconciliation.toml`
- `PYTHONPATH=src .venv/bin/python -m horse_bet_lab.forward_test.snapshot_bridge_cli --config configs/recurring_rehearsal/20260419_satsuki_sho.bridge.toml`
- `PYTHONPATH=src .venv/bin/python -m horse_bet_lab.forward_test.cli --config configs/recurring_rehearsal/20260419_satsuki_sho.pre_race.toml`
- `PYTHONPATH=src .venv/bin/python -m horse_bet_lab.forward_test.reconciliation_cli --config configs/recurring_rehearsal/20260419_satsuki_sho.reconciliation.toml`
- `PYTHONPATH=src .venv/bin/python -m horse_bet_lab.forward_test.snapshot_bridge_cli --config configs/recurring_rehearsal/20260419_failure_probe.bridge.toml`
- `PYTHONPATH=src .venv/bin/python -m horse_bet_lab.forward_test.cli --config configs/recurring_rehearsal/20260419_failure_probe.pre_race.toml`
- `PYTHONPATH=src .venv/bin/python -m horse_bet_lab.forward_test.reconciliation_cli --config configs/recurring_rehearsal/20260419_failure_probe.reconciliation.toml`

## Observed results
- recurring cadence ran across 3 run units
- settled path, unsettled path, and snapshot failure path were all observed
- operator pain points were narrowed to:
  - manual raw snapshot acquisition
  - result DB availability confirmation
  - multi-config edit overhead per run unit

## What this does NOT change
- no BET logic changes
- no baseline rewrite
- no threshold / surcharge / guard changes
- no popularity carrier resolution
- no frozen `win_odds` migration retry

## Follow-up still out of scope
- automate raw snapshot acquisition
- automate result DB availability check
- reduce per-run config editing overhead
- extend rehearsal over multiple weeks/meetings
