### PR TITLE
align scaffold defaults with odds-only recurring path

### DIFF
--- a/configs/recurring_rehearsal/20250420_satsuki_sho.bridge.toml
+++ b/configs/recurring_rehearsal/20250420_satsuki_sho.bridge.toml
@@ -1,0 +1,28 @@
+[place_forward_snapshot_bridge]
+name = "place_forward_snapshot_bridge_runtime_20250420_satsuki_sho"
+output_path = "data/forward_test/runs/20250420_satsuki_sho/contract/input_snapshot_20250420_satsuki_sho.csv"
+strict_race_key = true
+infer_snapshot_status = true
+write_json_copy = true
+
+[place_forward_snapshot_bridge.columns]
+race_key = "race_key"
+horse_number = "horse_number"
+win_odds = "win_odds"
+place_basis_odds_proxy = "place_basis_odds_proxy"
+popularity = "popularity"
+snapshot_status = "snapshot_status"
+retry_count = "retry_count"
+timeout_seconds = "timeout_seconds"
+snapshot_failure_reason = "snapshot_failure_reason"
+
+[[place_forward_snapshot_bridge.sources]]
+path = "data/forward_test/runs/20250420_satsuki_sho/raw/input_snapshot_raw.csv"
+input_source_name = "keibalab_public_pre_race_odds"
+input_source_url = "https://www.keibalab.jp/db/race/202504200611/odds.html"
+input_source_timestamp = "2025-04-20T15:48:00+09:00"
+odds_observation_timestamp = "2025-04-20T15:48:00+09:00"
+carrier_identity = "place_forward_live_snapshot_v1"
+default_retry_count = 1
+default_timeout_seconds = 15
+default_popularity_input_source = "keibalab_public_pre_race_odds"

--- a/configs/recurring_rehearsal/20250420_satsuki_sho.pre_race.toml
+++ b/configs/recurring_rehearsal/20250420_satsuki_sho.pre_race.toml
@@ -1,0 +1,28 @@
+[place_forward_test]
+name = "place_forward_test_phase1_20250420_satsuki_sho"
+input_path = "data/forward_test/runs/20250420_satsuki_sho/contract/input_snapshot_20250420_satsuki_sho.csv"
+output_dir = "data/artifacts/place_forward_test/20250420_satsuki_sho/pre_race"
+input_schema_version = "place_forward_test_input_v1"
+
+[place_forward_test.reference_model]
+dataset_path = "data/processed/horse_dataset_odds_only_is_place.parquet"
+model_name = "logistic_regression"
+feature_columns = ["win_odds"]
+feature_transforms = ["identity"]
+target_column = "target_value"
+split_column = "split"
+training_splits = ["train", "valid", "test"]
+max_iter = 1000
+model_version = "odds_only_logreg_is_place@recurring_rehearsal_20250420_satsuki_sho"
+
+[place_forward_test.reference_model.model_params]
+random_state = 42
+
+[place_forward_test.bet_logic]
+selection_metric = "edge"
+threshold = 0.08
+stake_per_bet = 100.0
+stronger_guard_edge_surcharge = 0.01
+candidate_logic_id = "guard_0_01_plus_proxy_domain_overlay"
+fallback_logic_id = "no_bet_guard_stronger"
+formal_domain_mapping_confirmed = true

--- a/configs/recurring_rehearsal/20250420_satsuki_sho.reconciliation.toml
+++ b/configs/recurring_rehearsal/20250420_satsuki_sho.reconciliation.toml
@@ -1,0 +1,6 @@
+[place_forward_reconciliation]
+name = "place_forward_test_reconciliation_20250420_satsuki_sho"
+forward_output_dir = "data/artifacts/place_forward_test/20250420_satsuki_sho/pre_race"
+duckdb_path = "data/artifacts/jrdb_2023_2025_supported_full.duckdb"
+output_dir = "data/artifacts/place_forward_test/20250420_satsuki_sho/reconciliation"
+settled_as_of = "2025-04-20T18:00:00+09:00"

--- a/configs/recurring_rehearsal/20250420_satsuki_sho_scaffold_aligned.bridge.toml
+++ b/configs/recurring_rehearsal/20250420_satsuki_sho_scaffold_aligned.bridge.toml
@@ -1,0 +1,31 @@
+# Runtime template for recurring place-only forward-test snapshot bridge runs.
+# Copy this file per rehearsal unit and replace placeholder values.
+
+[place_forward_snapshot_bridge]
+name = "place_forward_snapshot_bridge_runtime_20250420_satsuki_sho_scaffold_aligned"
+output_path = "data/forward_test/runs/20250420_satsuki_sho_scaffold_aligned/contract/input_snapshot_20250420_satsuki_sho_scaffold_aligned.csv"
+strict_race_key = true
+infer_snapshot_status = true
+write_json_copy = true
+
+[place_forward_snapshot_bridge.columns]
+race_key = "race_key"
+horse_number = "horse_number"
+win_odds = "win_odds"
+place_basis_odds_proxy = "place_basis_odds_proxy"
+popularity = "popularity"
+snapshot_status = "snapshot_status"
+retry_count = "retry_count"
+timeout_seconds = "timeout_seconds"
+snapshot_failure_reason = "snapshot_failure_reason"
+
+[[place_forward_snapshot_bridge.sources]]
+path = "data/forward_test/runs/20250420_satsuki_sho_scaffold_aligned/raw/input_snapshot_raw.csv"
+input_source_name = "keibalab_public_pre_race_odds"
+input_source_url = "https://www.keibalab.jp/db/race/202504200611/odds.html"
+input_source_timestamp = "2025-04-20T15:48:00+09:00"
+odds_observation_timestamp = "2025-04-20T15:48:00+09:00"
+carrier_identity = "place_forward_live_snapshot_v1"
+default_retry_count = 1
+default_timeout_seconds = 15
+default_popularity_input_source = "keibalab_public_pre_race_odds"

--- a/configs/recurring_rehearsal/20250420_satsuki_sho_scaffold_aligned.pre_race.toml
+++ b/configs/recurring_rehearsal/20250420_satsuki_sho_scaffold_aligned.pre_race.toml
@@ -2,13 +2,13 @@
 # Copy this file per rehearsal unit and replace placeholder values.
 
 [place_forward_test]
-name = "place_forward_test_phase1_<unit_id>"
-input_path = "data/forward_test/runs/<unit_id>/contract/input_snapshot_<unit_id>.csv"
-output_dir = "data/artifacts/place_forward_test/<unit_id>/pre_race"
+name = "place_forward_test_phase1_20250420_satsuki_sho_scaffold_aligned"
+input_path = "data/forward_test/runs/20250420_satsuki_sho_scaffold_aligned/contract/input_snapshot_20250420_satsuki_sho_scaffold_aligned.csv"
+output_dir = "data/artifacts/place_forward_test/20250420_satsuki_sho_scaffold_aligned/pre_race"
 input_schema_version = "place_forward_test_input_v1"
 
 [place_forward_test.reference_model]
-dataset_path = "data/processed/dataset_is_place/dataset.parquet"
+dataset_path = "data/processed/horse_dataset_odds_only_is_place.parquet"
 model_name = "logistic_regression"
 feature_columns = ["win_odds"]
 # Current recurring default is the odds-only path on top of the hard-adopt baseline.
@@ -17,7 +17,7 @@ target_column = "target_value"
 split_column = "split"
 training_splits = ["train", "valid", "test"]
 max_iter = 1000
-model_version = "replace_with_mainline_model_version"
+model_version = "odds_only_logreg_is_place@20250420_satsuki_sho_scaffold_aligned"
 
 [place_forward_test.reference_model.model_params]
 random_state = 42

--- a/configs/recurring_rehearsal/20250420_satsuki_sho_scaffold_aligned.reconciliation.toml
+++ b/configs/recurring_rehearsal/20250420_satsuki_sho_scaffold_aligned.reconciliation.toml
@@ -1,0 +1,9 @@
+# Runtime template for recurring place-only forward-test reconciliation runs.
+# Copy this file per rehearsal unit and replace placeholder values.
+
+[place_forward_reconciliation]
+name = "place_forward_test_reconciliation_20250420_satsuki_sho_scaffold_aligned"
+forward_output_dir = "data/artifacts/place_forward_test/20250420_satsuki_sho_scaffold_aligned/pre_race"
+duckdb_path = "data/artifacts/jrdb_2023_2025_supported_full.duckdb"
+output_dir = "data/artifacts/place_forward_test/20250420_satsuki_sho_scaffold_aligned/reconciliation"
+settled_as_of = "2025-04-20T18:00:00+09:00"

--- a/configs/recurring_rehearsal/20250420_satsuki_sho_scaffold_smoke.bridge.toml
+++ b/configs/recurring_rehearsal/20250420_satsuki_sho_scaffold_smoke.bridge.toml
@@ -1,0 +1,31 @@
+# Runtime template for recurring place-only forward-test snapshot bridge runs.
+# Copy this file per rehearsal unit and replace placeholder values.
+
+[place_forward_snapshot_bridge]
+name = "place_forward_snapshot_bridge_runtime_20250420_satsuki_sho_scaffold_smoke"
+output_path = "data/forward_test/runs/20250420_satsuki_sho_scaffold_smoke/contract/input_snapshot_20250420_satsuki_sho_scaffold_smoke.csv"
+strict_race_key = true
+infer_snapshot_status = true
+write_json_copy = true
+
+[place_forward_snapshot_bridge.columns]
+race_key = "race_key"
+horse_number = "horse_number"
+win_odds = "win_odds"
+place_basis_odds_proxy = "place_basis_odds_proxy"
+popularity = "popularity"
+snapshot_status = "snapshot_status"
+retry_count = "retry_count"
+timeout_seconds = "timeout_seconds"
+snapshot_failure_reason = "snapshot_failure_reason"
+
+[[place_forward_snapshot_bridge.sources]]
+path = "data/forward_test/runs/20250420_satsuki_sho_scaffold_smoke/raw/input_snapshot_raw.csv"
+input_source_name = "keibalab_public_pre_race_odds"
+input_source_url = "https://www.keibalab.jp/db/race/202504200611/odds.html"
+input_source_timestamp = "2025-04-20T15:48:00+09:00"
+odds_observation_timestamp = "2025-04-20T15:48:00+09:00"
+carrier_identity = "place_forward_live_snapshot_v1"
+default_retry_count = 1
+default_timeout_seconds = 15
+default_popularity_input_source = "keibalab_public_pre_race_odds"

--- a/configs/recurring_rehearsal/20250420_satsuki_sho_scaffold_smoke.pre_race.toml
+++ b/configs/recurring_rehearsal/20250420_satsuki_sho_scaffold_smoke.pre_race.toml
@@ -1,0 +1,31 @@
+# Runtime template for recurring place-only forward-test Phase 1 pre-race runs.
+# Copy this file per rehearsal unit and replace placeholder values.
+
+[place_forward_test]
+name = "place_forward_test_phase1_20250420_satsuki_sho_scaffold_smoke"
+input_path = "data/forward_test/runs/20250420_satsuki_sho_scaffold_smoke/contract/input_snapshot_20250420_satsuki_sho_scaffold_smoke.csv"
+output_dir = "data/artifacts/place_forward_test/20250420_satsuki_sho_scaffold_smoke/pre_race"
+input_schema_version = "place_forward_test_input_v1"
+
+[place_forward_test.reference_model]
+dataset_path = "data/processed/horse_dataset_odds_only_is_place.parquet"
+model_name = "logistic_regression"
+feature_columns = ["win_odds"]
+feature_transforms = ["identity"]
+target_column = "target_value"
+split_column = "split"
+training_splits = ["train", "valid", "test"]
+max_iter = 1000
+model_version = "odds_only_logreg_is_place@20250420_satsuki_sho_scaffold_smoke"
+
+[place_forward_test.reference_model.model_params]
+random_state = 42
+
+[place_forward_test.bet_logic]
+selection_metric = "edge"
+threshold = 0.08
+stake_per_bet = 100.0
+stronger_guard_edge_surcharge = 0.01
+candidate_logic_id = "guard_0_01_plus_proxy_domain_overlay"
+fallback_logic_id = "no_bet_guard_stronger"
+formal_domain_mapping_confirmed = true

--- a/configs/recurring_rehearsal/20250420_satsuki_sho_scaffold_smoke.reconciliation.toml
+++ b/configs/recurring_rehearsal/20250420_satsuki_sho_scaffold_smoke.reconciliation.toml
@@ -1,0 +1,9 @@
+# Runtime template for recurring place-only forward-test reconciliation runs.
+# Copy this file per rehearsal unit and replace placeholder values.
+
+[place_forward_reconciliation]
+name = "place_forward_test_reconciliation_20250420_satsuki_sho_scaffold_smoke"
+forward_output_dir = "data/artifacts/place_forward_test/20250420_satsuki_sho_scaffold_smoke/pre_race"
+duckdb_path = "data/artifacts/jrdb_2023_2025_supported_full.duckdb"
+output_dir = "data/artifacts/place_forward_test/20250420_satsuki_sho_scaffold_smoke/reconciliation"
+settled_as_of = "2025-04-20T18:00:00+09:00"

--- a/configs/recurring_rehearsal/20260419_failure_probe.bridge.toml
+++ b/configs/recurring_rehearsal/20260419_failure_probe.bridge.toml
@@ -1,0 +1,28 @@
+[place_forward_snapshot_bridge]
+name = "place_forward_snapshot_bridge_runtime_20260419_failure_probe"
+output_path = "data/forward_test/runs/20260419_failure_probe/contract/input_snapshot_20260419_failure_probe.csv"
+strict_race_key = true
+infer_snapshot_status = true
+write_json_copy = true
+
+[place_forward_snapshot_bridge.columns]
+race_key = "race_key"
+horse_number = "horse_number"
+win_odds = "win_odds"
+place_basis_odds_proxy = "place_basis_odds_proxy"
+popularity = "popularity"
+snapshot_status = "snapshot_status"
+retry_count = "retry_count"
+timeout_seconds = "timeout_seconds"
+snapshot_failure_reason = "snapshot_failure_reason"
+
+[[place_forward_snapshot_bridge.sources]]
+path = "data/forward_test/runs/20260419_failure_probe/raw/input_snapshot_raw.csv"
+input_source_name = "operator_manual_failure_probe"
+input_source_url = "https://example.invalid/manual-failure-probe"
+input_source_timestamp = "2026-04-19T07:55:00+09:00"
+odds_observation_timestamp = "2026-04-19T07:55:00+09:00"
+carrier_identity = "place_forward_live_snapshot_v1"
+default_retry_count = 3
+default_timeout_seconds = 15
+default_popularity_input_source = "operator_manual_failure_probe"

--- a/configs/recurring_rehearsal/20260419_failure_probe.pre_race.toml
+++ b/configs/recurring_rehearsal/20260419_failure_probe.pre_race.toml
@@ -1,0 +1,28 @@
+[place_forward_test]
+name = "place_forward_test_phase1_20260419_failure_probe"
+input_path = "data/forward_test/runs/20260419_failure_probe/contract/input_snapshot_20260419_failure_probe.csv"
+output_dir = "data/artifacts/place_forward_test/20260419_failure_probe/pre_race"
+input_schema_version = "place_forward_test_input_v1"
+
+[place_forward_test.reference_model]
+dataset_path = "data/processed/horse_dataset_odds_only_is_place.parquet"
+model_name = "logistic_regression"
+feature_columns = ["win_odds"]
+feature_transforms = ["identity"]
+target_column = "target_value"
+split_column = "split"
+training_splits = ["train", "valid", "test"]
+max_iter = 1000
+model_version = "odds_only_logreg_is_place@recurring_rehearsal_20260419_failure_probe"
+
+[place_forward_test.reference_model.model_params]
+random_state = 42
+
+[place_forward_test.bet_logic]
+selection_metric = "edge"
+threshold = 0.08
+stake_per_bet = 100.0
+stronger_guard_edge_surcharge = 0.01
+candidate_logic_id = "guard_0_01_plus_proxy_domain_overlay"
+fallback_logic_id = "no_bet_guard_stronger"
+formal_domain_mapping_confirmed = true

--- a/configs/recurring_rehearsal/20260419_failure_probe.reconciliation.toml
+++ b/configs/recurring_rehearsal/20260419_failure_probe.reconciliation.toml
@@ -1,0 +1,6 @@
+[place_forward_reconciliation]
+name = "place_forward_test_reconciliation_20260419_failure_probe"
+forward_output_dir = "data/artifacts/place_forward_test/20260419_failure_probe/pre_race"
+duckdb_path = "data/artifacts/jrdb_2023_2025_supported_full.duckdb"
+output_dir = "data/artifacts/place_forward_test/20260419_failure_probe/reconciliation"
+settled_as_of = "2026-04-20T18:00:00+09:00"

--- a/configs/recurring_rehearsal/20260419_satsuki_sho.bridge.toml
+++ b/configs/recurring_rehearsal/20260419_satsuki_sho.bridge.toml
@@ -1,0 +1,28 @@
+[place_forward_snapshot_bridge]
+name = "place_forward_snapshot_bridge_runtime_20260419_satsuki_sho"
+output_path = "data/forward_test/runs/20260419_satsuki_sho/contract/input_snapshot_20260419_satsuki_sho.csv"
+strict_race_key = true
+infer_snapshot_status = true
+write_json_copy = true
+
+[place_forward_snapshot_bridge.columns]
+race_key = "race_key"
+horse_number = "horse_number"
+win_odds = "win_odds"
+place_basis_odds_proxy = "place_basis_odds_proxy"
+popularity = "popularity"
+snapshot_status = "snapshot_status"
+retry_count = "retry_count"
+timeout_seconds = "timeout_seconds"
+snapshot_failure_reason = "snapshot_failure_reason"
+
+[[place_forward_snapshot_bridge.sources]]
+path = "data/forward_test/runs/20260419_satsuki_sho/raw/input_snapshot_raw.csv"
+input_source_name = "keibalab_public_pre_race_odds"
+input_source_url = "https://www.keibalab.jp/db/race/202604190611/odds.html"
+input_source_timestamp = "2026-04-18T07:50:00+09:00"
+odds_observation_timestamp = "2026-04-18T07:50:00+09:00"
+carrier_identity = "place_forward_live_snapshot_v1"
+default_retry_count = 1
+default_timeout_seconds = 15
+default_popularity_input_source = "keibalab_public_pre_race_odds"

--- a/configs/recurring_rehearsal/20260419_satsuki_sho.pre_race.toml
+++ b/configs/recurring_rehearsal/20260419_satsuki_sho.pre_race.toml
@@ -1,0 +1,28 @@
+[place_forward_test]
+name = "place_forward_test_phase1_20260419_satsuki_sho"
+input_path = "data/forward_test/runs/20260419_satsuki_sho/contract/input_snapshot_20260419_satsuki_sho.csv"
+output_dir = "data/artifacts/place_forward_test/20260419_satsuki_sho/pre_race"
+input_schema_version = "place_forward_test_input_v1"
+
+[place_forward_test.reference_model]
+dataset_path = "data/processed/horse_dataset_odds_only_is_place.parquet"
+model_name = "logistic_regression"
+feature_columns = ["win_odds"]
+feature_transforms = ["identity"]
+target_column = "target_value"
+split_column = "split"
+training_splits = ["train", "valid", "test"]
+max_iter = 1000
+model_version = "odds_only_logreg_is_place@recurring_rehearsal_20260419_satsuki_sho"
+
+[place_forward_test.reference_model.model_params]
+random_state = 42
+
+[place_forward_test.bet_logic]
+selection_metric = "edge"
+threshold = 0.08
+stake_per_bet = 100.0
+stronger_guard_edge_surcharge = 0.01
+candidate_logic_id = "guard_0_01_plus_proxy_domain_overlay"
+fallback_logic_id = "no_bet_guard_stronger"
+formal_domain_mapping_confirmed = true

--- a/configs/recurring_rehearsal/20260419_satsuki_sho.reconciliation.toml
+++ b/configs/recurring_rehearsal/20260419_satsuki_sho.reconciliation.toml
@@ -1,0 +1,6 @@
+[place_forward_reconciliation]
+name = "place_forward_test_reconciliation_20260419_satsuki_sho"
+forward_output_dir = "data/artifacts/place_forward_test/20260419_satsuki_sho/pre_race"
+duckdb_path = "data/artifacts/jrdb_2023_2025_supported_full.duckdb"
+output_dir = "data/artifacts/place_forward_test/20260419_satsuki_sho/reconciliation"
+settled_as_of = "2026-04-20T18:00:00+09:00"

--- a/configs/templates/place_forward_snapshot_bridge_runtime.template.toml
+++ b/configs/templates/place_forward_snapshot_bridge_runtime.template.toml
@@ -1,0 +1,31 @@
+# Runtime template for recurring place-only forward-test snapshot bridge runs.
+# Copy this file per rehearsal unit and replace placeholder values.
+
+[place_forward_snapshot_bridge]
+name = "place_forward_snapshot_bridge_runtime_<unit_id>"
+output_path = "data/forward_test/runs/<unit_id>/contract/input_snapshot_<unit_id>.csv"
+strict_race_key = true
+infer_snapshot_status = true
+write_json_copy = true
+
+[place_forward_snapshot_bridge.columns]
+race_key = "race_key"
+horse_number = "horse_number"
+win_odds = "win_odds"
+place_basis_odds_proxy = "place_basis_odds_proxy"
+popularity = "popularity"
+snapshot_status = "snapshot_status"
+retry_count = "retry_count"
+timeout_seconds = "timeout_seconds"
+snapshot_failure_reason = "snapshot_failure_reason"
+
+[[place_forward_snapshot_bridge.sources]]
+path = "data/forward_test/runs/<unit_id>/raw/input_snapshot_raw.csv"
+input_source_name = "replace_with_source_name"
+input_source_url = "https://replace.example/source"
+input_source_timestamp = "2026-04-20T15:30:00+09:00"
+odds_observation_timestamp = "2026-04-20T15:30:00+09:00"
+carrier_identity = "place_forward_live_snapshot_v1"
+default_retry_count = 1
+default_timeout_seconds = 15
+default_popularity_input_source = "replace_with_popularity_source_or_leave_same_as_source"

--- a/configs/templates/place_forward_test_phase1_runtime.template.toml
+++ b/configs/templates/place_forward_test_phase1_runtime.template.toml
@@ -1,0 +1,31 @@
+# Runtime template for recurring place-only forward-test Phase 1 pre-race runs.
+# Copy this file per rehearsal unit and replace placeholder values.
+
+[place_forward_test]
+name = "place_forward_test_phase1_<unit_id>"
+input_path = "data/forward_test/runs/<unit_id>/contract/input_snapshot_<unit_id>.csv"
+output_dir = "data/artifacts/place_forward_test/<unit_id>/pre_race"
+input_schema_version = "place_forward_test_input_v1"
+
+[place_forward_test.reference_model]
+dataset_path = "data/processed/dataset_is_place/dataset.parquet"
+model_name = "logreg"
+feature_columns = ["win_odds"]
+feature_transforms = []
+target_column = "target_value"
+split_column = "split"
+training_splits = ["train", "valid", "test"]
+max_iter = 1000
+model_version = "replace_with_mainline_model_version"
+
+[place_forward_test.reference_model.model_params]
+random_state = 42
+
+[place_forward_test.bet_logic]
+selection_metric = "edge"
+threshold = 0.08
+stake_per_bet = 100.0
+stronger_guard_edge_surcharge = 0.01
+candidate_logic_id = "guard_0_01_plus_proxy_domain_overlay"
+fallback_logic_id = "no_bet_guard_stronger"
+formal_domain_mapping_confirmed = true

--- a/configs/templates/place_forward_test_reconciliation_runtime.template.toml
+++ b/configs/templates/place_forward_test_reconciliation_runtime.template.toml
@@ -1,0 +1,9 @@
+# Runtime template for recurring place-only forward-test reconciliation runs.
+# Copy this file per rehearsal unit and replace placeholder values.
+
+[place_forward_reconciliation]
+name = "place_forward_test_reconciliation_<unit_id>"
+forward_output_dir = "data/artifacts/place_forward_test/<unit_id>/pre_race"
+duckdb_path = "data/artifacts/jrdb_2023_2025_supported_full.duckdb"
+output_dir = "data/artifacts/place_forward_test/<unit_id>/reconciliation"
+settled_as_of = "2026-04-20T18:00:00+09:00"

--- a/docs/checkpoints/place_forward_test_recurring_weekly_review_2026W17.md
+++ b/docs/checkpoints/place_forward_test_recurring_weekly_review_2026W17.md
@@ -1,0 +1,48 @@
+# Place Forward-Test Recurring Weekly Review 2026W17
+
+## Run units reviewed
+
+- `20250420_satsuki_sho`
+- `20260419_satsuki_sho`
+- `20260419_failure_probe`
+
+## Per-unit summary
+
+### 20250420_satsuki_sho
+
+- bridge: `ok=18`
+- pre-race: `bets=2`, `no_bet=16`
+- no-bet reasons: `logic_filtered=16`
+- reconciliation: `settled_hit=1`, `settled_miss=1`, `settled_no_bet=16`
+- result: fully settled
+
+### 20260419_satsuki_sho
+
+- bridge: `ok=18`
+- pre-race: `bets=4`, `no_bet=14`
+- no-bet reasons: `logic_filtered=14`
+- reconciliation: `unsettled_result_pending=18`
+- result: operationally successful, but result DB side still pending
+
+### 20260419_failure_probe
+
+- bridge: `timeout=1`, `required_odds_missing=1`
+- pre-race: `bets=0`, `no_bet=2`
+- no-bet reasons: `timeout=1`, `required_odds_missing=1`
+- reconciliation: `unsettled_result_pending=2`
+- result: failure-state path behaved as expected
+
+## Operator pain points found
+
+- raw snapshot acquisition is still manual before the bridge step
+- recurring cadence is understandable, but each unit still requires three small runtime configs
+- result DB availability is the main source of ambiguity after race day
+  - a unit can be procedurally complete while remaining fully `unsettled_result_pending`
+- weekly review needs one place where settled units and pending units are separated immediately
+
+## Conclusion
+
+- recurring cadence is usable as an operator rehearsal path
+- naming convention and directory layout did not break across multiple run units
+- snapshot failure states and logic-filter states remained readable
+- the next practical improvement is to keep repeating the weekly cadence and reduce manual overhead around raw snapshot acquisition and result DB confirmation

--- a/docs/runbooks/place_forward_test_phase1_recurring_rehearsal.md
+++ b/docs/runbooks/place_forward_test_phase1_recurring_rehearsal.md
@@ -84,11 +84,14 @@ data/forward_test/runs/<unit_id>/notes/
 2. raw snapshot CSV を `raw/` に置く
 3. scaffold で 3 つの runtime config をまとめて生成する
 4. bridge config の source metadata と raw path を確認する
-5. bridge を実行する
-6. generated contract CSV と bridge manifest を確認する
-7. current baseline の bet logic identifiers が変わっていないことを確認する
-8. pre-race runner を実行する
-9. `bet_decision_records.csv` と `run_manifest.json` を確認する
+5. pre-race config の `reference_model` を確認する
+6. current odds-only recurring path を使う場合は `model_name = "logistic_regression"` になっていることを確認する
+7. current odds-only recurring path を使う場合は `feature_columns = ["win_odds"]` と `feature_transforms = ["identity"]` の組み合わせになっていることを確認する
+8. bridge を実行する
+9. generated contract CSV と bridge manifest を確認する
+10. current baseline の bet logic identifiers が変わっていないことを確認する
+11. pre-race runner を実行する
+12. `bet_decision_records.csv` と `run_manifest.json` を確認する
 
 ### Post-race checklist
 
@@ -174,6 +177,10 @@ PYTHONPATH=src .venv/bin/python -m horse_bet_lab.forward_test.scaffold_cli \
 - scaffold は hidden fallback を入れない
 - 既存 config がある場合は default で overwrite せず clear error で止まる
 - 生成後に source metadata や `settled_as_of` を見直してから bridge / pre-race / reconciliation を実行する
+- current odds-only recurring path では、generated pre-race config の `model_name = "logistic_regression"` と `feature_transforms = ["identity"]` を確認する
+- operator smoke では、scaffold 実行後の still-manual は主に 2 系統だった
+  - raw snapshot を `raw/input_snapshot_raw.csv` に置くこと
+  - pre-race config の `reference_model` を current odds-only path に合わせて確認すること
 
 ## Boundaries
 

--- a/docs/runbooks/place_forward_test_phase1_recurring_rehearsal.md
+++ b/docs/runbooks/place_forward_test_phase1_recurring_rehearsal.md
@@ -85,13 +85,12 @@ data/forward_test/runs/<unit_id>/notes/
 3. scaffold で 3 つの runtime config をまとめて生成する
 4. bridge config の source metadata と raw path を確認する
 5. pre-race config の `reference_model` を確認する
-6. current odds-only recurring path を使う場合は `model_name = "logistic_regression"` になっていることを確認する
-7. current odds-only recurring path を使う場合は `feature_columns = ["win_odds"]` と `feature_transforms = ["identity"]` の組み合わせになっていることを確認する
-8. bridge を実行する
-9. generated contract CSV と bridge manifest を確認する
-10. current baseline の bet logic identifiers が変わっていないことを確認する
-11. pre-race runner を実行する
-12. `bet_decision_records.csv` と `run_manifest.json` を確認する
+6. current odds-only recurring path を使う場合は `feature_columns = ["win_odds"]` と `feature_transforms = ["identity"]` の組み合わせになっていることを軽く確認する
+7. bridge を実行する
+8. generated contract CSV と bridge manifest を確認する
+9. current baseline の bet logic identifiers が変わっていないことを確認する
+10. pre-race runner を実行する
+11. `bet_decision_records.csv` と `run_manifest.json` を確認する
 
 ### Post-race checklist
 
@@ -177,10 +176,10 @@ PYTHONPATH=src .venv/bin/python -m horse_bet_lab.forward_test.scaffold_cli \
 - scaffold は hidden fallback を入れない
 - 既存 config がある場合は default で overwrite せず clear error で止まる
 - 生成後に source metadata や `settled_as_of` を見直してから bridge / pre-race / reconciliation を実行する
-- current odds-only recurring path では、generated pre-race config の `model_name = "logistic_regression"` と `feature_transforms = ["identity"]` を確認する
+- current odds-only recurring path 向けの scaffold default は `model_name = "logistic_regression"` と `feature_transforms = ["identity"]`
 - operator smoke では、scaffold 実行後の still-manual は主に 2 系統だった
   - raw snapshot を `raw/input_snapshot_raw.csv` に置くこと
-  - pre-race config の `reference_model` を current odds-only path に合わせて確認すること
+  - pre-race config の `reference_model` を軽く見直すこと
 
 ## Boundaries
 

--- a/docs/runbooks/place_forward_test_phase1_recurring_rehearsal.md
+++ b/docs/runbooks/place_forward_test_phase1_recurring_rehearsal.md
@@ -82,10 +82,10 @@ data/forward_test/runs/<unit_id>/notes/
 
 1. 今日の rehearsal unit id を決める
 2. raw snapshot CSV を `raw/` に置く
-3. `configs/templates/place_forward_snapshot_bridge_runtime.template.toml` をコピーして source path と metadata を埋める
-4. bridge を実行する
-5. generated contract CSV と bridge manifest を確認する
-6. `configs/templates/place_forward_test_phase1_runtime.template.toml` をコピーして `input_path` / `output_dir` / `dataset_path` / `model_version` を埋める
+3. scaffold で 3 つの runtime config をまとめて生成する
+4. bridge config の source metadata と raw path を確認する
+5. bridge を実行する
+6. generated contract CSV と bridge manifest を確認する
 7. current baseline の bet logic identifiers が変わっていないことを確認する
 8. pre-race runner を実行する
 9. `bet_decision_records.csv` と `run_manifest.json` を確認する
@@ -93,7 +93,7 @@ data/forward_test/runs/<unit_id>/notes/
 ### Post-race checklist
 
 1. result DB が対象開催まで更新済みかを確認する
-2. `configs/templates/place_forward_test_reconciliation_runtime.template.toml` をコピーして `forward_output_dir` / `duckdb_path` / `output_dir` / `settled_as_of` を埋める
+2. scaffold が生成した reconciliation config の `duckdb_path` / `settled_as_of` を確認する
 3. reconciliation を実行する
 4. `reconciled_records.csv` を確認する
 5. `reconciliation_summary.json` を確認する
@@ -144,6 +144,36 @@ data/forward_test/runs/<unit_id>/notes/
   - [configs/templates/place_forward_test_phase1_runtime.template.toml](/Users/matsurimbpblack/Library/Mobile%20Documents/com~apple~CloudDocs/codex_projects/horse-bet-lab/configs/templates/place_forward_test_phase1_runtime.template.toml)
 - reconciliation runtime template:
   - [configs/templates/place_forward_test_reconciliation_runtime.template.toml](/Users/matsurimbpblack/Library/Mobile%20Documents/com~apple~CloudDocs/codex_projects/horse-bet-lab/configs/templates/place_forward_test_reconciliation_runtime.template.toml)
+
+## Scaffold Helper
+
+run-unit ごとの 3 config を毎回手で複製したくない場合は、scaffold を使って bridge / pre-race / reconciliation の runtime config をまとめて生成できる。
+
+例:
+
+```bash
+PYTHONPATH=src .venv/bin/python -m horse_bet_lab.forward_test.scaffold_cli \
+  --unit-id 20260426_example_meeting \
+  --dataset-path data/processed/horse_dataset_odds_only_is_place.parquet \
+  --duckdb-path data/artifacts/jrdb_2023_2025_supported_full.duckdb \
+  --model-version odds_only_logreg_is_place@20260426_example_meeting \
+  --settled-as-of 2026-04-26T18:00:00+09:00
+```
+
+生成されるもの:
+
+- `configs/recurring_rehearsal/<unit_id>.bridge.toml`
+- `configs/recurring_rehearsal/<unit_id>.pre_race.toml`
+- `configs/recurring_rehearsal/<unit_id>.reconciliation.toml`
+- `data/forward_test/runs/<unit_id>/raw/`
+- `data/forward_test/runs/<unit_id>/contract/`
+- `data/forward_test/runs/<unit_id>/notes/`
+
+注意:
+
+- scaffold は hidden fallback を入れない
+- 既存 config がある場合は default で overwrite せず clear error で止まる
+- 生成後に source metadata や `settled_as_of` を見直してから bridge / pre-race / reconciliation を実行する
 
 ## Boundaries
 

--- a/docs/runbooks/place_forward_test_phase1_recurring_rehearsal.md
+++ b/docs/runbooks/place_forward_test_phase1_recurring_rehearsal.md
@@ -29,6 +29,7 @@
 - その週の run units をざっと見直す
 - `logic_filtered` と snapshot failure 系 reason の比率を確認する
 - settled / unsettled の残りを確認し、必要なら archive note を残す
+- result DB 未更新による `unsettled_result_pending` と operator 側の手順ミスを混同しない
 
 ## Recommended Directory And Naming Convention
 
@@ -105,6 +106,8 @@ data/forward_test/runs/<unit_id>/notes/
 3. `logic_filtered` が極端に偏っていないか確認する
 4. unsettled のまま残っている unit を確認する
 5. 次週も同じ命名規則と template で回せるか確認する
+
+週次メモを残すときの雛形は [docs/runbooks/place_forward_test_phase1_weekly_review_template.md](/Users/matsurimbpblack/Library/Mobile%20Documents/com~apple~CloudDocs/codex_projects/horse-bet-lab/docs/runbooks/place_forward_test_phase1_weekly_review_template.md:1) を使う。
 
 ## Artifact Reading Guide
 

--- a/docs/runbooks/place_forward_test_phase1_recurring_rehearsal.md
+++ b/docs/runbooks/place_forward_test_phase1_recurring_rehearsal.md
@@ -1,0 +1,151 @@
+# Place Forward-Test Phase 1 Recurring Rehearsal
+
+## Purpose
+
+この文書は、place-only forward-test Phase 1 を単発 example ではなく、同じ手順で繰り返し回せる最小運用リハーサルとして固定するための cadence / checklist / naming rule をまとめるものです。
+
+対象は current mainline baseline の複勝一本 path です。
+
+- current candidate: `guard_0_01_plus_proxy_domain_overlay`
+- status: `hard_adopt`
+- fallback: `no_bet_guard_stronger surcharge=0.01`
+
+## Recurring Cadence
+
+### Race day pre-race run
+
+- raw/live-ish snapshot を当日分として収集する
+- bridge で contract CSV に変換する
+- pre-race runner を回して prediction / decision artifact を保存する
+
+### Result-confirmed post-race reconciliation
+
+- result DB が更新済みかを確認する
+- reconciliation を回して settled / unsettled を確定する
+- 当日の run と reconciliation artifact を同じ rehearsal unit として残す
+
+### Weekly review / archive
+
+- その週の run units をざっと見直す
+- `logic_filtered` と snapshot failure 系 reason の比率を確認する
+- settled / unsettled の残りを確認し、必要なら archive note を残す
+
+## Recommended Directory And Naming Convention
+
+rehearsal unit は `YYYYMMDD_meeting_slug` を基本単位にする。
+
+例:
+
+- unit id: `20250420_satsuki_sho`
+
+推奨配置:
+
+```text
+data/forward_test/runs/<unit_id>/raw/
+data/forward_test/runs/<unit_id>/contract/
+data/artifacts/place_forward_test/<unit_id>/pre_race/
+data/artifacts/place_forward_test/<unit_id>/reconciliation/
+data/forward_test/runs/<unit_id>/notes/
+```
+
+役割:
+
+- `raw/`
+  - live-ish snapshot input を置く
+- `contract/`
+  - bridge で生成した contract CSV / JSON / manifest を置く
+- `pre_race/`
+  - runner output を置く
+- `reconciliation/`
+  - reconciliation output を置く
+- `notes/`
+  - operator memo や週次メモを置く
+
+命名原則:
+
+- bridge output:
+  - `input_snapshot_<unit_id>.csv`
+  - `input_snapshot_<unit_id>.json`
+  - `input_snapshot_<unit_id>.manifest.json`
+  - `input_snapshot_<unit_id>.summary.txt`
+- pre-race output dir:
+  - `data/artifacts/place_forward_test/<unit_id>/pre_race`
+- reconciliation output dir:
+  - `data/artifacts/place_forward_test/<unit_id>/reconciliation`
+- optional note:
+  - `data/forward_test/runs/<unit_id>/notes/operator_note.md`
+
+## Checklist
+
+### Pre-race checklist
+
+1. 今日の rehearsal unit id を決める
+2. raw snapshot CSV を `raw/` に置く
+3. `configs/templates/place_forward_snapshot_bridge_runtime.template.toml` をコピーして source path と metadata を埋める
+4. bridge を実行する
+5. generated contract CSV と bridge manifest を確認する
+6. `configs/templates/place_forward_test_phase1_runtime.template.toml` をコピーして `input_path` / `output_dir` / `dataset_path` / `model_version` を埋める
+7. current baseline の bet logic identifiers が変わっていないことを確認する
+8. pre-race runner を実行する
+9. `bet_decision_records.csv` と `run_manifest.json` を確認する
+
+### Post-race checklist
+
+1. result DB が対象開催まで更新済みかを確認する
+2. `configs/templates/place_forward_test_reconciliation_runtime.template.toml` をコピーして `forward_output_dir` / `duckdb_path` / `output_dir` / `settled_as_of` を埋める
+3. reconciliation を実行する
+4. `reconciled_records.csv` を確認する
+5. `reconciliation_summary.json` を確認する
+6. `settled_hit`, `settled_miss`, `settled_no_bet`, `unsettled_*` の件数を確認する
+
+### Weekly / periodic checklist
+
+1. その週の rehearsal units を列挙する
+2. snapshot failure 系 reason が増えていないか確認する
+3. `logic_filtered` が極端に偏っていないか確認する
+4. unsettled のまま残っている unit を確認する
+5. 次週も同じ命名規則と template で回せるか確認する
+
+## Artifact Reading Guide
+
+最初に見る場所:
+
+- bridge 成功確認:
+  - `contract/input_snapshot_<unit_id>.summary.txt`
+  - `contract/input_snapshot_<unit_id>.manifest.json`
+- pre-race 判断確認:
+  - `pre_race/bet_decision_records.csv`
+  - `pre_race/run_manifest.json`
+- post-race 結果確認:
+  - `reconciliation/reconciled_records.csv`
+  - `reconciliation/reconciliation_summary.json`
+
+読み分けの最短ルール:
+
+- `logic_filtered`
+  - contract は通って prediction まで進んだが、BET logic 条件で `no_bet`
+- `timeout`, `required_odds_missing`, `snapshot_failure`, `retry_exhausted`
+  - snapshot failure 系の `no_bet`
+- `settled_hit`, `settled_miss`
+  - 当時 `bet` だった行の post-race outcome
+- `settled_no_bet`
+  - 結果は出たが当時は `no_bet`
+- `unsettled_result_pending`, `unsettled_result_incomplete`
+  - まだ結果確認が閉じていない
+
+## Template Files
+
+- bridge runtime template:
+  - [configs/templates/place_forward_snapshot_bridge_runtime.template.toml](/Users/matsurimbpblack/Library/Mobile%20Documents/com~apple~CloudDocs/codex_projects/horse-bet-lab/configs/templates/place_forward_snapshot_bridge_runtime.template.toml)
+- pre-race runtime template:
+  - [configs/templates/place_forward_test_phase1_runtime.template.toml](/Users/matsurimbpblack/Library/Mobile%20Documents/com~apple~CloudDocs/codex_projects/horse-bet-lab/configs/templates/place_forward_test_phase1_runtime.template.toml)
+- reconciliation runtime template:
+  - [configs/templates/place_forward_test_reconciliation_runtime.template.toml](/Users/matsurimbpblack/Library/Mobile%20Documents/com~apple~CloudDocs/codex_projects/horse-bet-lab/configs/templates/place_forward_test_reconciliation_runtime.template.toml)
+
+## Boundaries
+
+- BET logic は変えない
+- baseline は変えない
+- `popularity` は unresolved auxiliary のまま扱う
+- frozen `win_odds` migration は再開しない
+- 自動購入 / 外部連携は Phase 1 に含めない

--- a/docs/runbooks/place_forward_test_phase1_runbook.md
+++ b/docs/runbooks/place_forward_test_phase1_runbook.md
@@ -6,6 +6,8 @@
 
 対象は `horse_bet_lab.forward_test.runner` の Phase 1 path です。runner 本体のロジックはここでは変更しません。
 
+繰り返し運用の cadence / checklist / naming rule は [docs/runbooks/place_forward_test_phase1_recurring_rehearsal.md](/Users/matsurimbpblack/Library/Mobile%20Documents/com~apple~CloudDocs/codex_projects/horse-bet-lab/docs/runbooks/place_forward_test_phase1_recurring_rehearsal.md:1) を参照してください。
+
 ## Scope
 
 - 複勝一本

--- a/docs/runbooks/place_forward_test_phase1_weekly_review_template.md
+++ b/docs/runbooks/place_forward_test_phase1_weekly_review_template.md
@@ -1,0 +1,38 @@
+# Place Forward-Test Phase 1 Weekly Review Template
+
+## Week
+
+- week id:
+- review date:
+
+## Run units reviewed
+
+- `<unit_id>`
+
+## Per-unit status
+
+- settled units:
+- pending units:
+- snapshot failure probe units:
+
+## Key counts
+
+- total bets:
+- total no_bet:
+- settled hits:
+- settled misses:
+- settled no_bet:
+- unsettled result pending:
+
+## Operator pain points
+
+- raw snapshot acquisition:
+- config copy/edit burden:
+- result DB availability check:
+- artifact reading friction:
+
+## Follow-up for next week
+
+- checklist change needed or not:
+- naming convention change needed or not:
+- units to carry forward:

--- a/src/horse_bet_lab/forward_test/__init__.py
+++ b/src/horse_bet_lab/forward_test/__init__.py
@@ -35,6 +35,14 @@ from horse_bet_lab.forward_test.snapshot_bridge import (
     load_snapshot_bridge_config,
     run_snapshot_bridge,
 )
+from horse_bet_lab.forward_test.scaffold import (
+    PlaceForwardScaffoldConfig,
+    PlaceForwardScaffoldResult,
+    build_scaffold_config_from_args,
+    build_scaffold_parser,
+    run_scaffold,
+    validate_unit_id,
+)
 
 __all__ = [
     "PLACE_FORWARD_TEST_CONTRACT_VERSION",
@@ -51,19 +59,25 @@ __all__ = [
     "PlaceForwardReconciliationConfig",
     "PlaceForwardReconciliationResult",
     "PlaceForwardRunResult",
+    "PlaceForwardScaffoldConfig",
+    "PlaceForwardScaffoldResult",
     "PlaceForwardSnapshotBridgeConfig",
     "PlaceForwardSnapshotBridgeResult",
     "PlaceForwardTestConfig",
     "build_place_forward_artifact_provenance",
     "build_parser",
     "build_reconciliation_parser",
+    "build_scaffold_config_from_args",
+    "build_scaffold_parser",
     "build_snapshot_bridge_parser",
     "load_config",
     "load_reconciliation_config",
     "load_snapshot_bridge_config",
     "run_place_forward_reconciliation",
+    "run_scaffold",
     "run_snapshot_bridge",
     "run_place_forward_test",
     "validate_place_forward_input_record",
     "validate_place_forward_input_records",
+    "validate_unit_id",
 ]

--- a/src/horse_bet_lab/forward_test/scaffold.py
+++ b/src/horse_bet_lab/forward_test/scaffold.py
@@ -1,0 +1,375 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_TEMPLATE_DIR = REPO_ROOT / "configs" / "templates"
+DEFAULT_CANDIDATE_LOGIC_ID = "guard_0_01_plus_proxy_domain_overlay"
+DEFAULT_FALLBACK_LOGIC_ID = "no_bet_guard_stronger"
+DEFAULT_THRESHOLD = 0.08
+DEFAULT_STAKE_PER_BET = 100.0
+DEFAULT_SURCHARGE = 0.01
+DEFAULT_INPUT_SCHEMA_VERSION = "place_forward_test_input_v1"
+DEFAULT_BRIDGE_SOURCE_NAME = "replace_with_source_name"
+DEFAULT_BRIDGE_SOURCE_URL = "https://replace.example/source"
+DEFAULT_BRIDGE_SOURCE_TIMESTAMP = "2026-04-20T15:30:00+09:00"
+DEFAULT_ODDS_OBSERVATION_TIMESTAMP = "2026-04-20T15:30:00+09:00"
+DEFAULT_CARRIER_IDENTITY = "place_forward_live_snapshot_v1"
+DEFAULT_RETRY_COUNT = 1
+DEFAULT_TIMEOUT_SECONDS = 15.0
+DEFAULT_POPULARITY_INPUT_SOURCE = "replace_with_popularity_source_or_leave_same_as_source"
+
+
+@dataclass(frozen=True)
+class PlaceForwardScaffoldConfig:
+    unit_id: str
+    raw_input_path: Path
+    contract_output_path: Path
+    pre_race_output_dir: Path
+    reconciliation_output_dir: Path
+    dataset_path: Path
+    duckdb_path: Path
+    model_version: str
+    candidate_logic_id: str
+    fallback_logic_id: str
+    threshold: float
+    settled_as_of: str
+    config_dir: Path
+    bridge_config_path: Path
+    pre_race_config_path: Path
+    reconciliation_config_path: Path
+    notes_dir: Path
+    input_source_name: str
+    input_source_url: str
+    input_source_timestamp: str
+    odds_observation_timestamp: str
+    carrier_identity: str
+    retry_count: int
+    timeout_seconds: float
+    popularity_input_source: str
+    force: bool
+
+
+@dataclass(frozen=True)
+class PlaceForwardScaffoldResult:
+    bridge_config_path: Path
+    pre_race_config_path: Path
+    reconciliation_config_path: Path
+    raw_dir: Path
+    contract_dir: Path
+    notes_dir: Path
+    pre_race_output_dir: Path
+    reconciliation_output_dir: Path
+
+
+def build_scaffold_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Generate recurring rehearsal bridge/pre-race/reconciliation configs for one run unit.",
+    )
+    parser.add_argument("--unit-id", required=True, help="Rehearsal unit id, e.g. 20260426_example_meeting.")
+    parser.add_argument("--dataset-path", type=Path, required=True, help="Reference model dataset parquet path.")
+    parser.add_argument("--duckdb-path", type=Path, required=True, help="JRDB DuckDB path for reconciliation.")
+    parser.add_argument("--model-version", required=True, help="Model version label written into pre-race config.")
+    parser.add_argument("--settled-as-of", required=True, help="ISO-8601 timestamp for reconciliation settled_as_of.")
+    parser.add_argument(
+        "--config-dir",
+        type=Path,
+        default=Path("configs/recurring_rehearsal"),
+        help="Directory where generated runtime configs are written.",
+    )
+    parser.add_argument(
+        "--raw-input-path",
+        type=Path,
+        help="Raw input CSV path for bridge source. Defaults to data/forward_test/runs/<unit_id>/raw/input_snapshot_raw.csv.",
+    )
+    parser.add_argument(
+        "--contract-output-path",
+        type=Path,
+        help="Bridge contract CSV output path. Defaults to data/forward_test/runs/<unit_id>/contract/input_snapshot_<unit_id>.csv.",
+    )
+    parser.add_argument(
+        "--pre-race-output-dir",
+        type=Path,
+        help="Pre-race artifact output dir. Defaults to data/artifacts/place_forward_test/<unit_id>/pre_race.",
+    )
+    parser.add_argument(
+        "--reconciliation-output-dir",
+        type=Path,
+        help="Reconciliation artifact output dir. Defaults to data/artifacts/place_forward_test/<unit_id>/reconciliation.",
+    )
+    parser.add_argument(
+        "--candidate-logic-id",
+        default=DEFAULT_CANDIDATE_LOGIC_ID,
+        help="BET logic candidate id. Defaults to the current hard-adopt candidate.",
+    )
+    parser.add_argument(
+        "--fallback-logic-id",
+        default=DEFAULT_FALLBACK_LOGIC_ID,
+        help="BET logic fallback id. Defaults to the current hard-adopt fallback.",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=DEFAULT_THRESHOLD,
+        help="BET logic threshold to write into the pre-race config.",
+    )
+    parser.add_argument("--input-source-name", default=DEFAULT_BRIDGE_SOURCE_NAME, help="Bridge source name.")
+    parser.add_argument("--input-source-url", default=DEFAULT_BRIDGE_SOURCE_URL, help="Bridge source URL.")
+    parser.add_argument(
+        "--input-source-timestamp",
+        default=DEFAULT_BRIDGE_SOURCE_TIMESTAMP,
+        help="Bridge source timestamp in ISO-8601 format.",
+    )
+    parser.add_argument(
+        "--odds-observation-timestamp",
+        default=DEFAULT_ODDS_OBSERVATION_TIMESTAMP,
+        help="Odds observation timestamp in ISO-8601 format.",
+    )
+    parser.add_argument(
+        "--carrier-identity",
+        default=DEFAULT_CARRIER_IDENTITY,
+        help="Carrier identity to write into bridge config.",
+    )
+    parser.add_argument(
+        "--retry-count",
+        type=int,
+        default=DEFAULT_RETRY_COUNT,
+        help="Default retry count for bridge sources.",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=DEFAULT_TIMEOUT_SECONDS,
+        help="Default timeout seconds for bridge sources.",
+    )
+    parser.add_argument(
+        "--popularity-input-source",
+        default=DEFAULT_POPULARITY_INPUT_SOURCE,
+        help="Popularity input source label kept as unresolved auxiliary metadata.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Allow overwriting existing generated runtime config files.",
+    )
+    return parser
+
+
+def build_scaffold_config_from_args(args: argparse.Namespace) -> PlaceForwardScaffoldConfig:
+    unit_id = validate_unit_id(str(args.unit_id))
+    raw_input_path = args.raw_input_path or Path(
+        f"data/forward_test/runs/{unit_id}/raw/input_snapshot_raw.csv"
+    )
+    contract_output_path = args.contract_output_path or Path(
+        f"data/forward_test/runs/{unit_id}/contract/input_snapshot_{unit_id}.csv"
+    )
+    pre_race_output_dir = args.pre_race_output_dir or Path(
+        f"data/artifacts/place_forward_test/{unit_id}/pre_race"
+    )
+    reconciliation_output_dir = args.reconciliation_output_dir or Path(
+        f"data/artifacts/place_forward_test/{unit_id}/reconciliation"
+    )
+    config_dir = Path(args.config_dir)
+    return PlaceForwardScaffoldConfig(
+        unit_id=unit_id,
+        raw_input_path=raw_input_path,
+        contract_output_path=contract_output_path,
+        pre_race_output_dir=pre_race_output_dir,
+        reconciliation_output_dir=reconciliation_output_dir,
+        dataset_path=Path(args.dataset_path),
+        duckdb_path=Path(args.duckdb_path),
+        model_version=str(args.model_version),
+        candidate_logic_id=str(args.candidate_logic_id),
+        fallback_logic_id=str(args.fallback_logic_id),
+        threshold=float(args.threshold),
+        settled_as_of=str(args.settled_as_of),
+        config_dir=config_dir,
+        bridge_config_path=config_dir / f"{unit_id}.bridge.toml",
+        pre_race_config_path=config_dir / f"{unit_id}.pre_race.toml",
+        reconciliation_config_path=config_dir / f"{unit_id}.reconciliation.toml",
+        notes_dir=Path(f"data/forward_test/runs/{unit_id}/notes"),
+        input_source_name=str(args.input_source_name),
+        input_source_url=str(args.input_source_url),
+        input_source_timestamp=str(args.input_source_timestamp),
+        odds_observation_timestamp=str(args.odds_observation_timestamp),
+        carrier_identity=str(args.carrier_identity),
+        retry_count=int(args.retry_count),
+        timeout_seconds=float(args.timeout_seconds),
+        popularity_input_source=str(args.popularity_input_source),
+        force=bool(args.force),
+    )
+
+
+def validate_unit_id(unit_id: str) -> str:
+    cleaned = unit_id.strip()
+    if not cleaned:
+        raise ValueError("unit_id must be non-empty")
+    allowed = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-")
+    invalid = sorted({character for character in cleaned if character not in allowed})
+    if invalid:
+        raise ValueError(
+            "unit_id may contain only letters, digits, underscore, and hyphen; "
+            f"got invalid characters: {invalid}"
+        )
+    return cleaned
+
+
+def run_scaffold(config: PlaceForwardScaffoldConfig) -> PlaceForwardScaffoldResult:
+    ensure_outputs_do_not_exist(
+        (
+            config.bridge_config_path,
+            config.pre_race_config_path,
+            config.reconciliation_config_path,
+        ),
+        force=config.force,
+    )
+    template_dir = DEFAULT_TEMPLATE_DIR
+    bridge_text = render_bridge_template(
+        (template_dir / "place_forward_snapshot_bridge_runtime.template.toml").read_text(
+            encoding="utf-8"
+        ),
+        config,
+    )
+    pre_race_text = render_pre_race_template(
+        (template_dir / "place_forward_test_phase1_runtime.template.toml").read_text(
+            encoding="utf-8"
+        ),
+        config,
+    )
+    reconciliation_text = render_reconciliation_template(
+        (template_dir / "place_forward_test_reconciliation_runtime.template.toml").read_text(
+            encoding="utf-8"
+        ),
+        config,
+    )
+
+    config.config_dir.mkdir(parents=True, exist_ok=True)
+    config.raw_input_path.parent.mkdir(parents=True, exist_ok=True)
+    config.contract_output_path.parent.mkdir(parents=True, exist_ok=True)
+    config.notes_dir.mkdir(parents=True, exist_ok=True)
+    config.pre_race_output_dir.mkdir(parents=True, exist_ok=True)
+    config.reconciliation_output_dir.mkdir(parents=True, exist_ok=True)
+
+    config.bridge_config_path.write_text(bridge_text, encoding="utf-8")
+    config.pre_race_config_path.write_text(pre_race_text, encoding="utf-8")
+    config.reconciliation_config_path.write_text(reconciliation_text, encoding="utf-8")
+
+    return PlaceForwardScaffoldResult(
+        bridge_config_path=config.bridge_config_path,
+        pre_race_config_path=config.pre_race_config_path,
+        reconciliation_config_path=config.reconciliation_config_path,
+        raw_dir=config.raw_input_path.parent,
+        contract_dir=config.contract_output_path.parent,
+        notes_dir=config.notes_dir,
+        pre_race_output_dir=config.pre_race_output_dir,
+        reconciliation_output_dir=config.reconciliation_output_dir,
+    )
+
+
+def ensure_outputs_do_not_exist(paths: tuple[Path, ...], *, force: bool) -> None:
+    existing_paths = [path for path in paths if path.exists()]
+    if existing_paths and not force:
+        raise FileExistsError(
+            "run-unit scaffold refuses to overwrite existing files without --force: "
+            f"{[str(path) for path in existing_paths]}"
+        )
+
+
+def render_bridge_template(template_text: str, config: PlaceForwardScaffoldConfig) -> str:
+    rendered = template_text.replace("<unit_id>", config.unit_id)
+    lines: list[str] = []
+    for line in rendered.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("output_path = "):
+            lines.append(f'output_path = "{toml_string(config.contract_output_path)}"')
+        elif stripped.startswith("path = "):
+            lines.append(f'path = "{toml_string(config.raw_input_path)}"')
+        elif stripped.startswith("input_source_name = "):
+            lines.append(f'input_source_name = "{toml_string(config.input_source_name)}"')
+        elif stripped.startswith("input_source_url = "):
+            lines.append(f'input_source_url = "{toml_string(config.input_source_url)}"')
+        elif stripped.startswith("input_source_timestamp = "):
+            lines.append(
+                f'input_source_timestamp = "{toml_string(config.input_source_timestamp)}"'
+            )
+        elif stripped.startswith("odds_observation_timestamp = "):
+            lines.append(
+                f'odds_observation_timestamp = "{toml_string(config.odds_observation_timestamp)}"'
+            )
+        elif stripped.startswith("carrier_identity = "):
+            lines.append(f'carrier_identity = "{toml_string(config.carrier_identity)}"')
+        elif stripped.startswith("default_retry_count = "):
+            lines.append(f"default_retry_count = {config.retry_count}")
+        elif stripped.startswith("default_timeout_seconds = "):
+            timeout_value = int(config.timeout_seconds) if config.timeout_seconds.is_integer() else config.timeout_seconds
+            lines.append(f"default_timeout_seconds = {timeout_value}")
+        elif stripped.startswith("default_popularity_input_source = "):
+            lines.append(
+                f'default_popularity_input_source = "{toml_string(config.popularity_input_source)}"'
+            )
+        else:
+            lines.append(line)
+    return "\n".join(lines) + "\n"
+
+
+def render_pre_race_template(template_text: str, config: PlaceForwardScaffoldConfig) -> str:
+    rendered = template_text.replace("<unit_id>", config.unit_id)
+    lines: list[str] = []
+    for line in rendered.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("input_path = "):
+            lines.append(f'input_path = "{toml_string(config.contract_output_path)}"')
+        elif stripped.startswith("output_dir = "):
+            lines.append(f'output_dir = "{toml_string(config.pre_race_output_dir)}"')
+        elif stripped.startswith("dataset_path = "):
+            lines.append(f'dataset_path = "{toml_string(config.dataset_path)}"')
+        elif stripped.startswith("model_version = "):
+            lines.append(f'model_version = "{toml_string(config.model_version)}"')
+        elif stripped.startswith("threshold = "):
+            lines.append(f"threshold = {config.threshold}")
+        elif stripped.startswith("candidate_logic_id = "):
+            lines.append(f'candidate_logic_id = "{toml_string(config.candidate_logic_id)}"')
+        elif stripped.startswith("fallback_logic_id = "):
+            lines.append(f'fallback_logic_id = "{toml_string(config.fallback_logic_id)}"')
+        else:
+            lines.append(line)
+    return "\n".join(lines) + "\n"
+
+
+def render_reconciliation_template(template_text: str, config: PlaceForwardScaffoldConfig) -> str:
+    rendered = template_text.replace("<unit_id>", config.unit_id)
+    lines: list[str] = []
+    for line in rendered.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("forward_output_dir = "):
+            lines.append(f'forward_output_dir = "{toml_string(config.pre_race_output_dir)}"')
+        elif stripped.startswith("duckdb_path = "):
+            lines.append(f'duckdb_path = "{toml_string(config.duckdb_path)}"')
+        elif stripped.startswith("output_dir = "):
+            lines.append(
+                f'output_dir = "{toml_string(config.reconciliation_output_dir)}"'
+            )
+        elif stripped.startswith("settled_as_of = "):
+            lines.append(f'settled_as_of = "{toml_string(config.settled_as_of)}"')
+        else:
+            lines.append(line)
+    return "\n".join(lines) + "\n"
+
+
+def toml_string(path_or_text: Path | str) -> str:
+    text = str(path_or_text).replace("\\", "\\\\").replace('"', '\\"')
+    return text
+
+
+def main() -> int:
+    parser = build_scaffold_parser()
+    args = parser.parse_args()
+    run_scaffold(build_scaffold_config_from_args(args))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/horse_bet_lab/forward_test/scaffold_cli.py
+++ b/src/horse_bet_lab/forward_test/scaffold_cli.py
@@ -1,0 +1,5 @@
+from horse_bet_lab.forward_test.scaffold import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_place_forward_test_scaffold.py
+++ b/tests/test_place_forward_test_scaffold.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+from horse_bet_lab.forward_test.reconciliation import load_reconciliation_config
+from horse_bet_lab.forward_test.runner import load_config
+from horse_bet_lab.forward_test.scaffold import (
+    build_scaffold_config_from_args,
+    run_scaffold,
+    validate_unit_id,
+)
+from horse_bet_lab.forward_test.snapshot_bridge import load_snapshot_bridge_config
+
+
+def make_args(tmp_path: Path, *, force: bool = False) -> Namespace:
+    return Namespace(
+        unit_id="20260426_example_meeting",
+        dataset_path=tmp_path / "dataset.parquet",
+        duckdb_path=tmp_path / "jrdb.duckdb",
+        model_version="odds_only_logreg_is_place@scaffold-test",
+        settled_as_of="2026-04-26T18:00:00+09:00",
+        config_dir=tmp_path / "configs",
+        raw_input_path=None,
+        contract_output_path=None,
+        pre_race_output_dir=None,
+        reconciliation_output_dir=None,
+        candidate_logic_id="guard_0_01_plus_proxy_domain_overlay",
+        fallback_logic_id="no_bet_guard_stronger",
+        threshold=0.08,
+        input_source_name="keibalab_public_pre_race_odds",
+        input_source_url="https://www.keibalab.jp/db/race/202604260611/odds.html",
+        input_source_timestamp="2026-04-26T15:38:00+09:00",
+        odds_observation_timestamp="2026-04-26T15:38:00+09:00",
+        carrier_identity="place_forward_live_snapshot_v1",
+        retry_count=1,
+        timeout_seconds=15.0,
+        popularity_input_source="keibalab_public_pre_race_odds",
+        force=force,
+    )
+
+
+def test_scaffold_generates_three_runtime_configs_and_directories(tmp_path: Path) -> None:
+    config = build_scaffold_config_from_args(make_args(tmp_path))
+
+    result = run_scaffold(config)
+
+    assert result.bridge_config_path.exists()
+    assert result.pre_race_config_path.exists()
+    assert result.reconciliation_config_path.exists()
+    assert result.raw_dir.exists()
+    assert result.contract_dir.exists()
+    assert result.notes_dir.exists()
+    assert result.pre_race_output_dir.exists()
+    assert result.reconciliation_output_dir.exists()
+
+    bridge_config = load_snapshot_bridge_config(result.bridge_config_path)
+    assert bridge_config.output_path == config.contract_output_path
+    assert bridge_config.sources[0].path == config.raw_input_path
+    assert bridge_config.sources[0].input_source_name == "keibalab_public_pre_race_odds"
+
+    pre_race_config = load_config(result.pre_race_config_path)
+    assert pre_race_config.input_path == config.contract_output_path
+    assert pre_race_config.output_dir == config.pre_race_output_dir
+    assert pre_race_config.reference_model.dataset_path == config.dataset_path
+    assert pre_race_config.reference_model.model_version == config.model_version
+    assert pre_race_config.bet_logic.threshold == pytest.approx(0.08)
+
+    reconciliation_config = load_reconciliation_config(result.reconciliation_config_path)
+    assert reconciliation_config.forward_output_dir == config.pre_race_output_dir
+    assert reconciliation_config.duckdb_path == config.duckdb_path
+    assert reconciliation_config.output_dir == config.reconciliation_output_dir
+    assert reconciliation_config.settled_as_of == "2026-04-26T18:00:00+09:00"
+
+
+def test_scaffold_rejects_existing_runtime_configs_without_force(tmp_path: Path) -> None:
+    config = build_scaffold_config_from_args(make_args(tmp_path))
+    run_scaffold(config)
+
+    with pytest.raises(FileExistsError, match="refuses to overwrite existing files"):
+        run_scaffold(config)
+
+
+def test_scaffold_force_overwrites_existing_runtime_configs(tmp_path: Path) -> None:
+    config = build_scaffold_config_from_args(make_args(tmp_path))
+    run_scaffold(config)
+
+    bridge_before = config.bridge_config_path.read_text(encoding="utf-8")
+    config.bridge_config_path.write_text("# overwritten\n", encoding="utf-8")
+
+    forced = build_scaffold_config_from_args(make_args(tmp_path, force=True))
+    run_scaffold(forced)
+
+    bridge_after = config.bridge_config_path.read_text(encoding="utf-8")
+    assert bridge_after != "# overwritten\n"
+    assert bridge_after == bridge_before
+
+
+@pytest.mark.parametrize("unit_id", ["", "2026/0426", "2026 0426", "2026?0426"])
+def test_validate_unit_id_rejects_invalid_values(unit_id: str) -> None:
+    with pytest.raises(ValueError):
+        validate_unit_id(unit_id)

--- a/tests/test_place_forward_test_scaffold.py
+++ b/tests/test_place_forward_test_scaffold.py
@@ -65,6 +65,8 @@ def test_scaffold_generates_three_runtime_configs_and_directories(tmp_path: Path
     assert pre_race_config.input_path == config.contract_output_path
     assert pre_race_config.output_dir == config.pre_race_output_dir
     assert pre_race_config.reference_model.dataset_path == config.dataset_path
+    assert pre_race_config.reference_model.model_name == "logistic_regression"
+    assert pre_race_config.reference_model.feature_transforms == ("identity",)
     assert pre_race_config.reference_model.model_version == config.model_version
     assert pre_race_config.bet_logic.threshold == pytest.approx(0.08)
 


### PR DESCRIPTION
## Summary
- align the pre-race runtime template defaults with the current odds-only recurring path
- remove the recurring need to manually fix `model_name` and `feature_transforms` after scaffold generation
- keep scaffold output consistent with the current recurring place-only operator path
- verify the aligned scaffold through a new operator smoke unit
- keep current hard-adopt baseline, BET logic, and frozen carrier decisions unchanged

## Included commit
- `5fecf33` — `align scaffold defaults with odds-only recurring path`

## Scope
- `configs/templates/place_forward_test_phase1_runtime.template.toml`
- `tests/test_place_forward_test_scaffold.py`
- `docs/runbooks/place_forward_test_phase1_recurring_rehearsal.md`
- generated aligned rehearsal configs for smoke verification

## What changed
- default pre-race template values now match the current recurring odds-only path:
  - `model_name = "logistic_regression"`
  - `feature_transforms = ["identity"]`
- scaffold tests now verify that generated pre-race configs carry these defaults
- runbook notes were simplified accordingly

## Validation
Executed:
- `PYTHONPATH=src .venv/bin/python -m pytest tests/test_place_forward_test_scaffold.py`
- scaffold -> bridge -> pre-race -> reconciliation smoke with unit:
  - `20250420_satsuki_sho_scaffold_aligned`

Observed:
- no additional manual edits were needed in the generated pre-race config
- bridge: `records=18`, `ok=18`
- pre-race: `inputs=18`, `predictions=18`, `decisions=18`
- reconciliation: `settled_bets=2`, `unsettled_bets=0`, `hit_count=1`, `total_simulated_profit_loss=80.0`

## What this does NOT change
- no BET logic changes
- no baseline rewrite
- no threshold / surcharge / guard changes
- no popularity carrier resolution
- no frozen `win_odds` migration retry
- no raw snapshot acquisition automation
- no result DB availability automation

## Remaining manual steps
- provide raw snapshot input
- provide source metadata and `settled_as_of`
- confirm result DB availability