### PR TITLE
align scaffold defaults with odds-only recurring path

### DIFF
--- a/configs/recurring_rehearsal/20250420_satsuki_sho_scaffold_aligned.bridge.toml
+++ b/configs/recurring_rehearsal/20250420_satsuki_sho_scaffold_aligned.bridge.toml
@@ -1,0 +1,31 @@
+# Runtime template for recurring place-only forward-test snapshot bridge runs.
+# Copy this file per rehearsal unit and replace placeholder values.
+
+[place_forward_snapshot_bridge]
+name = "place_forward_snapshot_bridge_runtime_20250420_satsuki_sho_scaffold_aligned"
+output_path = "data/forward_test/runs/20250420_satsuki_sho_scaffold_aligned/contract/input_snapshot_20250420_satsuki_sho_scaffold_aligned.csv"
+strict_race_key = true
+infer_snapshot_status = true
+write_json_copy = true
+
+[place_forward_snapshot_bridge.columns]
+race_key = "race_key"
+horse_number = "horse_number"
+win_odds = "win_odds"
+place_basis_odds_proxy = "place_basis_odds_proxy"
+popularity = "popularity"
+snapshot_status = "snapshot_status"
+retry_count = "retry_count"
+timeout_seconds = "timeout_seconds"
+snapshot_failure_reason = "snapshot_failure_reason"
+
+[[place_forward_snapshot_bridge.sources]]
+path = "data/forward_test/runs/20250420_satsuki_sho_scaffold_aligned/raw/input_snapshot_raw.csv"
+input_source_name = "keibalab_public_pre_race_odds"
+input_source_url = "https://www.keibalab.jp/db/race/202504200611/odds.html"
+input_source_timestamp = "2025-04-20T15:48:00+09:00"
+odds_observation_timestamp = "2025-04-20T15:48:00+09:00"
+carrier_identity = "place_forward_live_snapshot_v1"
+default_retry_count = 1
+default_timeout_seconds = 15
+default_popularity_input_source = "keibalab_public_pre_race_odds"

--- a/configs/recurring_rehearsal/20250420_satsuki_sho_scaffold_aligned.pre_race.toml
+++ b/configs/recurring_rehearsal/20250420_satsuki_sho_scaffold_aligned.pre_race.toml
@@ -2,13 +2,13 @@
 # Copy this file per rehearsal unit and replace placeholder values.
 
 [place_forward_test]
-name = "place_forward_test_phase1_<unit_id>"
-input_path = "data/forward_test/runs/<unit_id>/contract/input_snapshot_<unit_id>.csv"
-output_dir = "data/artifacts/place_forward_test/<unit_id>/pre_race"
+name = "place_forward_test_phase1_20250420_satsuki_sho_scaffold_aligned"
+input_path = "data/forward_test/runs/20250420_satsuki_sho_scaffold_aligned/contract/input_snapshot_20250420_satsuki_sho_scaffold_aligned.csv"
+output_dir = "data/artifacts/place_forward_test/20250420_satsuki_sho_scaffold_aligned/pre_race"
 input_schema_version = "place_forward_test_input_v1"
 
 [place_forward_test.reference_model]
-dataset_path = "data/processed/dataset_is_place/dataset.parquet"
+dataset_path = "data/processed/horse_dataset_odds_only_is_place.parquet"
 model_name = "logistic_regression"
 feature_columns = ["win_odds"]
 # Current recurring default is the odds-only path on top of the hard-adopt baseline.
@@ -17,7 +17,7 @@ target_column = "target_value"
 split_column = "split"
 training_splits = ["train", "valid", "test"]
 max_iter = 1000
-model_version = "replace_with_mainline_model_version"
+model_version = "odds_only_logreg_is_place@20250420_satsuki_sho_scaffold_aligned"
 
 [place_forward_test.reference_model.model_params]
 random_state = 42

--- a/configs/recurring_rehearsal/20250420_satsuki_sho_scaffold_aligned.reconciliation.toml
+++ b/configs/recurring_rehearsal/20250420_satsuki_sho_scaffold_aligned.reconciliation.toml
@@ -1,0 +1,9 @@
+# Runtime template for recurring place-only forward-test reconciliation runs.
+# Copy this file per rehearsal unit and replace placeholder values.
+
+[place_forward_reconciliation]
+name = "place_forward_test_reconciliation_20250420_satsuki_sho_scaffold_aligned"
+forward_output_dir = "data/artifacts/place_forward_test/20250420_satsuki_sho_scaffold_aligned/pre_race"
+duckdb_path = "data/artifacts/jrdb_2023_2025_supported_full.duckdb"
+output_dir = "data/artifacts/place_forward_test/20250420_satsuki_sho_scaffold_aligned/reconciliation"
+settled_as_of = "2025-04-20T18:00:00+09:00"

--- a/docs/runbooks/place_forward_test_phase1_recurring_rehearsal.md
+++ b/docs/runbooks/place_forward_test_phase1_recurring_rehearsal.md
@@ -82,18 +82,20 @@ data/forward_test/runs/<unit_id>/notes/
 
 1. 今日の rehearsal unit id を決める
 2. raw snapshot CSV を `raw/` に置く
-3. `configs/templates/place_forward_snapshot_bridge_runtime.template.toml` をコピーして source path と metadata を埋める
-4. bridge を実行する
-5. generated contract CSV と bridge manifest を確認する
-6. `configs/templates/place_forward_test_phase1_runtime.template.toml` をコピーして `input_path` / `output_dir` / `dataset_path` / `model_version` を埋める
-7. current baseline の bet logic identifiers が変わっていないことを確認する
-8. pre-race runner を実行する
-9. `bet_decision_records.csv` と `run_manifest.json` を確認する
+3. scaffold で 3 つの runtime config をまとめて生成する
+4. bridge config の source metadata と raw path を確認する
+5. pre-race config の `reference_model` を確認する
+6. current odds-only recurring path を使う場合は `feature_columns = ["win_odds"]` と `feature_transforms = ["identity"]` の組み合わせになっていることを軽く確認する
+7. bridge を実行する
+8. generated contract CSV と bridge manifest を確認する
+9. current baseline の bet logic identifiers が変わっていないことを確認する
+10. pre-race runner を実行する
+11. `bet_decision_records.csv` と `run_manifest.json` を確認する
 
 ### Post-race checklist
 
 1. result DB が対象開催まで更新済みかを確認する
-2. `configs/templates/place_forward_test_reconciliation_runtime.template.toml` をコピーして `forward_output_dir` / `duckdb_path` / `output_dir` / `settled_as_of` を埋める
+2. scaffold が生成した reconciliation config の `duckdb_path` / `settled_as_of` を確認する
 3. reconciliation を実行する
 4. `reconciled_records.csv` を確認する
 5. `reconciliation_summary.json` を確認する
@@ -144,6 +146,40 @@ data/forward_test/runs/<unit_id>/notes/
   - [configs/templates/place_forward_test_phase1_runtime.template.toml](/Users/matsurimbpblack/Library/Mobile%20Documents/com~apple~CloudDocs/codex_projects/horse-bet-lab/configs/templates/place_forward_test_phase1_runtime.template.toml)
 - reconciliation runtime template:
   - [configs/templates/place_forward_test_reconciliation_runtime.template.toml](/Users/matsurimbpblack/Library/Mobile%20Documents/com~apple~CloudDocs/codex_projects/horse-bet-lab/configs/templates/place_forward_test_reconciliation_runtime.template.toml)
+
+## Scaffold Helper
+
+run-unit ごとの 3 config を毎回手で複製したくない場合は、scaffold を使って bridge / pre-race / reconciliation の runtime config をまとめて生成できる。
+
+例:
+
+```bash
+PYTHONPATH=src .venv/bin/python -m horse_bet_lab.forward_test.scaffold_cli \
+  --unit-id 20260426_example_meeting \
+  --dataset-path data/processed/horse_dataset_odds_only_is_place.parquet \
+  --duckdb-path data/artifacts/jrdb_2023_2025_supported_full.duckdb \
+  --model-version odds_only_logreg_is_place@20260426_example_meeting \
+  --settled-as-of 2026-04-26T18:00:00+09:00
+```
+
+生成されるもの:
+
+- `configs/recurring_rehearsal/<unit_id>.bridge.toml`
+- `configs/recurring_rehearsal/<unit_id>.pre_race.toml`
+- `configs/recurring_rehearsal/<unit_id>.reconciliation.toml`
+- `data/forward_test/runs/<unit_id>/raw/`
+- `data/forward_test/runs/<unit_id>/contract/`
+- `data/forward_test/runs/<unit_id>/notes/`
+
+注意:
+
+- scaffold は hidden fallback を入れない
+- 既存 config がある場合は default で overwrite せず clear error で止まる
+- 生成後に source metadata や `settled_as_of` を見直してから bridge / pre-race / reconciliation を実行する
+- current odds-only recurring path 向けの scaffold default は `model_name = "logistic_regression"` と `feature_transforms = ["identity"]`
+- operator smoke では、scaffold 実行後の still-manual は主に 2 系統だった
+  - raw snapshot を `raw/input_snapshot_raw.csv` に置くこと
+  - pre-race config の `reference_model` を軽く見直すこと
 
 ## Boundaries
 

--- a/tests/test_place_forward_test_scaffold.py
+++ b/tests/test_place_forward_test_scaffold.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+from horse_bet_lab.forward_test.reconciliation import load_reconciliation_config
+from horse_bet_lab.forward_test.runner import load_config
+from horse_bet_lab.forward_test.scaffold import (
+    build_scaffold_config_from_args,
+    run_scaffold,
+    validate_unit_id,
+)
+from horse_bet_lab.forward_test.snapshot_bridge import load_snapshot_bridge_config
+
+
+def make_args(tmp_path: Path, *, force: bool = False) -> Namespace:
+    return Namespace(
+        unit_id="20260426_example_meeting",
+        dataset_path=tmp_path / "dataset.parquet",
+        duckdb_path=tmp_path / "jrdb.duckdb",
+        model_version="odds_only_logreg_is_place@scaffold-test",
+        settled_as_of="2026-04-26T18:00:00+09:00",
+        config_dir=tmp_path / "configs",
+        raw_input_path=None,
+        contract_output_path=None,
+        pre_race_output_dir=None,
+        reconciliation_output_dir=None,
+        candidate_logic_id="guard_0_01_plus_proxy_domain_overlay",
+        fallback_logic_id="no_bet_guard_stronger",
+        threshold=0.08,
+        input_source_name="keibalab_public_pre_race_odds",
+        input_source_url="https://www.keibalab.jp/db/race/202604260611/odds.html",
+        input_source_timestamp="2026-04-26T15:38:00+09:00",
+        odds_observation_timestamp="2026-04-26T15:38:00+09:00",
+        carrier_identity="place_forward_live_snapshot_v1",
+        retry_count=1,
+        timeout_seconds=15.0,
+        popularity_input_source="keibalab_public_pre_race_odds",
+        force=force,
+    )
+
+
+def test_scaffold_generates_three_runtime_configs_and_directories(tmp_path: Path) -> None:
+    config = build_scaffold_config_from_args(make_args(tmp_path))
+
+    result = run_scaffold(config)
+
+    assert result.bridge_config_path.exists()
+    assert result.pre_race_config_path.exists()
+    assert result.reconciliation_config_path.exists()
+    assert result.raw_dir.exists()
+    assert result.contract_dir.exists()
+    assert result.notes_dir.exists()
+    assert result.pre_race_output_dir.exists()
+    assert result.reconciliation_output_dir.exists()
+
+    bridge_config = load_snapshot_bridge_config(result.bridge_config_path)
+    assert bridge_config.output_path == config.contract_output_path
+    assert bridge_config.sources[0].path == config.raw_input_path
+    assert bridge_config.sources[0].input_source_name == "keibalab_public_pre_race_odds"
+
+    pre_race_config = load_config(result.pre_race_config_path)
+    assert pre_race_config.input_path == config.contract_output_path
+    assert pre_race_config.output_dir == config.pre_race_output_dir
+    assert pre_race_config.reference_model.dataset_path == config.dataset_path
+    assert pre_race_config.reference_model.model_name == "logistic_regression"
+    assert pre_race_config.reference_model.feature_transforms == ("identity",)
+    assert pre_race_config.reference_model.model_version == config.model_version
+    assert pre_race_config.bet_logic.threshold == pytest.approx(0.08)
+
+    reconciliation_config = load_reconciliation_config(result.reconciliation_config_path)
+    assert reconciliation_config.forward_output_dir == config.pre_race_output_dir
+    assert reconciliation_config.duckdb_path == config.duckdb_path
+    assert reconciliation_config.output_dir == config.reconciliation_output_dir
+    assert reconciliation_config.settled_as_of == "2026-04-26T18:00:00+09:00"
+
+
+def test_scaffold_rejects_existing_runtime_configs_without_force(tmp_path: Path) -> None:
+    config = build_scaffold_config_from_args(make_args(tmp_path))
+    run_scaffold(config)
+
+    with pytest.raises(FileExistsError, match="refuses to overwrite existing files"):
+        run_scaffold(config)
+
+
+def test_scaffold_force_overwrites_existing_runtime_configs(tmp_path: Path) -> None:
+    config = build_scaffold_config_from_args(make_args(tmp_path))
+    run_scaffold(config)
+
+    bridge_before = config.bridge_config_path.read_text(encoding="utf-8")
+    config.bridge_config_path.write_text("# overwritten\n", encoding="utf-8")
+
+    forced = build_scaffold_config_from_args(make_args(tmp_path, force=True))
+    run_scaffold(forced)
+
+    bridge_after = config.bridge_config_path.read_text(encoding="utf-8")
+    assert bridge_after != "# overwritten\n"
+    assert bridge_after == bridge_before
+
+
+@pytest.mark.parametrize("unit_id", ["", "2026/0426", "2026 0426", "2026?0426"])
+def test_validate_unit_id_rejects_invalid_values(unit_id: str) -> None:
+    with pytest.raises(ValueError):
+        validate_unit_id(unit_id)


### PR DESCRIPTION
## Summary
- align the pre-race runtime template defaults with the current odds-only recurring path
- remove the recurring need to manually fix `model_name` and `feature_transforms` after scaffold generation
- keep scaffold output consistent with the current recurring place-only operator path
- verify the aligned scaffold through a new operator smoke unit
- keep current hard-adopt baseline, BET logic, and frozen carrier decisions unchanged

## Included commit
- `5fecf33` — `align scaffold defaults with odds-only recurring path`

## Scope
- `configs/templates/place_forward_test_phase1_runtime.template.toml`
- `tests/test_place_forward_test_scaffold.py`
- `docs/runbooks/place_forward_test_phase1_recurring_rehearsal.md`
- generated aligned rehearsal configs for smoke verification

## What changed
- default pre-race template values now match the current recurring odds-only path:
  - `model_name = "logistic_regression"`
  - `feature_transforms = ["identity"]`
- scaffold tests now verify that generated pre-race configs carry these defaults
- runbook notes were simplified accordingly

## Validation
Executed:
- `PYTHONPATH=src .venv/bin/python -m pytest tests/test_place_forward_test_scaffold.py`
- scaffold -> bridge -> pre-race -> reconciliation smoke with unit:
  - `20250420_satsuki_sho_scaffold_aligned`

Observed:
- no additional manual edits were needed in the generated pre-race config
- bridge: `records=18`, `ok=18`
- pre-race: `inputs=18`, `predictions=18`, `decisions=18`
- reconciliation: `settled_bets=2`, `unsettled_bets=0`, `hit_count=1`, `total_simulated_profit_loss=80.0`

## What this does NOT change
- no BET logic changes
- no baseline rewrite
- no threshold / surcharge / guard changes
- no popularity carrier resolution
- no frozen `win_odds` migration retry
- no raw snapshot acquisition automation
- no result DB availability automation

## Remaining manual steps
- provide raw snapshot input
- provide source metadata and `settled_as_of`
- confirm result DB availability