### PR TITLE
add thin operator aid for place forward-test result DB availability check

### DIFF
--- a/docs/runbooks/place_forward_test_phase1_recurring_rehearsal.md
+++ b/docs/runbooks/place_forward_test_phase1_recurring_rehearsal.md
@@ -96,12 +96,13 @@ data/forward_test/runs/<unit_id>/notes/
 
 ### Post-race checklist
 
-1. result DB が対象開催まで更新済みかを確認する
-2. scaffold が生成した reconciliation config の `duckdb_path` / `settled_as_of` を確認する
-3. reconciliation を実行する
-4. `reconciled_records.csv` を確認する
-5. `reconciliation_summary.json` を確認する
-6. `settled_hit`, `settled_miss`, `settled_no_bet`, `unsettled_*` の件数を確認する
+1. scaffold が生成した reconciliation config の `duckdb_path` / `settled_as_of` を確認する
+2. reconciliation 前に result DB availability check を実行する
+3. `result_availability_check.txt` を見て、`should_settle` か `expected_pending_or_stale_db` かを確認する
+4. reconciliation を実行する
+5. `reconciled_records.csv` を確認する
+6. `reconciliation_summary.json` を確認する
+7. `settled_hit`, `settled_miss`, `settled_no_bet`, `unsettled_*` の件数を確認する
 
 ### Weekly / periodic checklist
 
@@ -126,6 +127,8 @@ data/forward_test/runs/<unit_id>/notes/
   - `pre_race/bet_decision_records.csv`
   - `pre_race/run_manifest.json`
 - post-race 結果確認:
+  - `reconciliation/result_availability_check.txt`
+  - `reconciliation/result_availability_check.json`
   - `reconciliation/reconciled_records.csv`
   - `reconciliation/reconciliation_summary.json`
 
@@ -141,6 +144,7 @@ data/forward_test/runs/<unit_id>/notes/
   - 結果は出たが当時は `no_bet`
 - `unsettled_result_pending`, `unsettled_result_incomplete`
   - まだ結果確認が閉じていない
+  - reconciliation 前に `result_availability_check` で `expected_pending_or_stale_db` や `result_db_partial_results` が出ていれば、operator 手順ミスではなく result DB freshness の問題を先に疑う
 
 ## Template Files
 
@@ -187,6 +191,13 @@ PYTHONPATH=src .venv/bin/python -m horse_bet_lab.forward_test.scaffold_cli \
 ```bash
 PYTHONPATH=src .venv/bin/python -m horse_bet_lab.forward_test.raw_snapshot_intake_cli \
   --bridge-config configs/recurring_rehearsal/<unit_id>.bridge.toml
+```
+
+- reconciliation 前の result DB availability check 例:
+
+```bash
+PYTHONPATH=src .venv/bin/python -m horse_bet_lab.forward_test.result_db_availability_cli \
+  --config configs/recurring_rehearsal/<unit_id>.reconciliation.toml
 ```
 
 - current odds-only recurring path 向けの scaffold default は `model_name = "logistic_regression"` と `feature_transforms = ["identity"]`

--- a/docs/runbooks/place_forward_test_phase1_runbook.md
+++ b/docs/runbooks/place_forward_test_phase1_runbook.md
@@ -199,8 +199,10 @@ PYTHONPATH=src .venv/bin/python -m horse_bet_lab.forward_test.reconciliation_cli
 5. pre-race runner を実行する
 6. `bet_decision_records.csv` と `run_manifest.json` を確認する
 7. レース結果が確定したら reconciliation config を用意する
-8. reconciliation を実行する
-9. `reconciled_records.csv` と `reconciliation_summary.json` を確認する
+8. result DB availability check を実行する
+9. `result_availability_check.txt` / `.json` を見て `should_settle` か `expected_pending_or_stale_db` かを確認する
+10. reconciliation を実行する
+11. `reconciled_records.csv` と `reconciliation_summary.json` を確認する
 
 operator rehearsal で最短確認したい点:
 
@@ -218,6 +220,7 @@ PYTHONPATH=src .venv/bin/python -m horse_bet_lab.forward_test.cli --config confi
 post-race reconciliation 例:
 
 ```bash
+PYTHONPATH=src .venv/bin/python -m horse_bet_lab.forward_test.result_db_availability_cli --config configs/place_forward_test_reconciliation.sample.toml
 PYTHONPATH=src .venv/bin/python -m horse_bet_lab.forward_test.reconciliation_cli --config configs/place_forward_test_reconciliation.sample.toml
 ```
 
@@ -240,6 +243,22 @@ reconciliation config で最低限埋める項目:
   - reconciliation artifacts の出力先
 - `settled_as_of`
   - operator が「どの時点まで結果確認済みか」を残したいときの任意メタデータ
+
+result DB availability check で最初に見たいもの:
+
+- `result_availability_check.txt`
+- `result_availability_check.json`
+
+最短判断:
+
+- `should_settle`
+  - 対象 race の finish result と payout side が揃って見えているので、そのまま reconciliation を回してよい
+- `expected_pending_or_stale_db`
+  - まだ結果が入っていない想定か、DuckDB が古い可能性がある
+- `result_db_partial_results`
+  - 一部 race だけ見えているので、まだ待つ方が安全
+- `result_db_incomplete_payout_side`
+  - finish result は見えているが payout side が不完全なので、settlement 判断にはまだ早い
 
 ## What Appears Under output_dir
 

--- a/src/horse_bet_lab/forward_test/__init__.py
+++ b/src/horse_bet_lab/forward_test/__init__.py
@@ -23,9 +23,12 @@ from horse_bet_lab.forward_test.runner import (
 from horse_bet_lab.forward_test.reconciliation import (
     PlaceForwardReconciliationConfig,
     PlaceForwardReconciliationResult,
+    PlaceForwardResultAvailabilityCheckResult,
     PlaceForwardReconciledRecord,
     build_reconciliation_parser,
+    build_result_db_availability_parser,
     load_reconciliation_config,
+    run_place_forward_result_db_availability_check,
     run_place_forward_reconciliation,
 )
 from horse_bet_lab.forward_test.snapshot_bridge import (
@@ -67,6 +70,7 @@ __all__ = [
     "PlaceForwardReconciledRecord",
     "PlaceForwardReconciliationConfig",
     "PlaceForwardReconciliationResult",
+    "PlaceForwardResultAvailabilityCheckResult",
     "PlaceForwardRawSnapshotIntakeManifest",
     "PlaceForwardRawSnapshotPrecheckResult",
     "PlaceForwardRunResult",
@@ -79,6 +83,7 @@ __all__ = [
     "build_default_raw_snapshot_intake_manifest",
     "build_parser",
     "build_reconciliation_parser",
+    "build_result_db_availability_parser",
     "build_raw_snapshot_intake_parser",
     "build_scaffold_config_from_args",
     "build_scaffold_parser",
@@ -89,6 +94,7 @@ __all__ = [
     "load_raw_snapshot_intake_manifest",
     "load_snapshot_bridge_config",
     "run_place_forward_reconciliation",
+    "run_place_forward_result_db_availability_check",
     "run_raw_snapshot_intake_precheck",
     "run_scaffold",
     "run_snapshot_bridge",

--- a/src/horse_bet_lab/forward_test/reconciliation.py
+++ b/src/horse_bet_lab/forward_test/reconciliation.py
@@ -26,6 +26,10 @@ RECONCILIATION_STATUS_SETTLED_MISS = "settled_miss"
 RECONCILIATION_STATUS_SETTLED_NO_BET = "settled_no_bet"
 RECONCILIATION_STATUS_UNSETTLED_RESULT_PENDING = "unsettled_result_pending"
 RECONCILIATION_STATUS_UNSETTLED_RESULT_INCOMPLETE = "unsettled_result_incomplete"
+RESULT_DB_AVAILABILITY_SHOULD_SETTLE = "should_settle"
+RESULT_DB_AVAILABILITY_EXPECTED_PENDING_OR_STALE_DB = "expected_pending_or_stale_db"
+RESULT_DB_AVAILABILITY_PARTIAL_RESULTS = "result_db_partial_results"
+RESULT_DB_AVAILABILITY_INCOMPLETE_PAYOUT_SIDE = "result_db_incomplete_payout_side"
 
 
 @dataclass(frozen=True)
@@ -83,9 +87,35 @@ class PlaceForwardReconciliationResult:
     total_simulated_profit_loss: float
 
 
+@dataclass(frozen=True)
+class PlaceForwardResultAvailabilityCheckResult:
+    output_dir: Path
+    run_name: str
+    recommendation: str
+    total_races: int
+    total_requested_records: int
+    total_requested_bets: int
+    races_with_sed_rows: int
+    races_with_hjc_rows: int
+    requested_records_with_known_results: int
+
+
 def build_reconciliation_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Reconcile place-only forward-test artifacts against settled race results.",
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        required=True,
+        help="Path to a place forward-test reconciliation TOML config.",
+    )
+    return parser
+
+
+def build_result_db_availability_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Check whether result DB state looks ready for place forward-test reconciliation.",
     )
     parser.add_argument(
         "--config",
@@ -160,6 +190,47 @@ def run_place_forward_reconciliation(
         hit_count=int(summary_payload["hit_count"]),
         total_simulated_payout=float(summary_payload["total_simulated_payout"]),
         total_simulated_profit_loss=float(summary_payload["total_simulated_profit_loss"]),
+    )
+
+
+def run_place_forward_result_db_availability_check(
+    config: PlaceForwardReconciliationConfig,
+) -> PlaceForwardResultAvailabilityCheckResult:
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+    bundle = load_forward_artifact_bundle(config.forward_output_dir)
+    race_keys = tuple(sorted({record.race_key for record in bundle.input_records}))
+    result_rows = load_result_rows(duckdb_path=config.duckdb_path, race_keys=race_keys)
+    sed_race_summary, hjc_race_summary = load_result_availability_race_summary(
+        duckdb_path=config.duckdb_path,
+        race_keys=race_keys,
+    )
+    payload = build_result_availability_summary_payload(
+        config=config,
+        bundle=bundle,
+        result_rows=result_rows,
+        sed_race_summary=sed_race_summary,
+        hjc_race_summary=hjc_race_summary,
+    )
+    summary_json_path = config.output_dir / "result_availability_check.json"
+    summary_json_path.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    write_result_availability_summary_text(
+        path=config.output_dir / "result_availability_check.txt",
+        summary_payload=payload,
+    )
+    aggregate = payload["aggregate"]
+    return PlaceForwardResultAvailabilityCheckResult(
+        output_dir=config.output_dir,
+        run_name=str(payload["run_name"]),
+        recommendation=str(payload["recommendation"]),
+        total_races=int(aggregate["total_races"]),
+        total_requested_records=int(aggregate["total_requested_records"]),
+        total_requested_bets=int(aggregate["total_requested_bets"]),
+        races_with_sed_rows=int(aggregate["races_with_sed_rows"]),
+        races_with_hjc_rows=int(aggregate["races_with_hjc_rows"]),
+        requested_records_with_known_results=int(aggregate["requested_records_with_known_results"]),
     )
 
 
@@ -265,6 +336,81 @@ def load_result_rows(
             official_place_payout=float(payout) if payout is not None else None,
         )
     return output
+
+
+def load_result_availability_race_summary(
+    *,
+    duckdb_path: Path,
+    race_keys: tuple[str, ...],
+) -> tuple[dict[str, dict[str, int]], dict[str, dict[str, int]]]:
+    if not race_keys:
+        return {}, {}
+    connection = duckdb.connect(str(duckdb_path), read_only=True)
+    try:
+        placeholders = ", ".join(["?"] * len(race_keys))
+        sed_rows = connection.execute(
+            f"""
+            SELECT
+                race_key,
+                COUNT(*) AS sed_rows_found,
+                SUM(
+                    CASE
+                        WHEN result_date IS NOT NULL AND finish_position IS NOT NULL THEN 1
+                        ELSE 0
+                    END
+                ) AS known_result_rows
+            FROM jrdb_sed_staging
+            WHERE race_key IN ({placeholders})
+            GROUP BY race_key
+            ORDER BY race_key
+            """,
+            [*race_keys],
+        ).fetchall()
+        hjc_rows = connection.execute(
+            f"""
+            WITH place_payout_rows AS (
+                SELECT race_key, place_horse_number_1 AS horse_number
+                FROM jrdb_hjc_staging
+                WHERE place_horse_number_1 IS NOT NULL
+                UNION ALL
+                SELECT race_key, place_horse_number_2 AS horse_number
+                FROM jrdb_hjc_staging
+                WHERE place_horse_number_2 IS NOT NULL
+                UNION ALL
+                SELECT race_key, place_horse_number_3 AS horse_number
+                FROM jrdb_hjc_staging
+                WHERE place_horse_number_3 IS NOT NULL
+            )
+            SELECT
+                h.race_key,
+                COUNT(*) AS hjc_rows_found,
+                COUNT(p.horse_number) AS payout_rows_found
+            FROM jrdb_hjc_staging h
+            LEFT JOIN place_payout_rows p
+                ON h.race_key = p.race_key
+            WHERE h.race_key IN ({placeholders})
+            GROUP BY h.race_key
+            ORDER BY h.race_key
+            """,
+            [*race_keys],
+        ).fetchall()
+    finally:
+        connection.close()
+    sed_output = {
+        str(race_key): {
+            "sed_rows_found": int(sed_rows_found),
+            "known_result_rows": int(known_result_rows or 0),
+        }
+        for race_key, sed_rows_found, known_result_rows in sed_rows
+    }
+    hjc_output = {
+        str(race_key): {
+            "hjc_rows_found": int(hjc_rows_found),
+            "payout_rows_found": int(payout_rows_found or 0),
+        }
+        for race_key, hjc_rows_found, payout_rows_found in hjc_rows
+    }
+    return sed_output, hjc_output
 
 
 def reconcile_forward_records(
@@ -424,6 +570,163 @@ def build_reconciliation_summary_payload(
     }
 
 
+def build_result_availability_summary_payload(
+    *,
+    config: PlaceForwardReconciliationConfig,
+    bundle: ForwardArtifactBundle,
+    result_rows: dict[tuple[str, int], PlaceForwardResultRecord],
+    sed_race_summary: dict[str, dict[str, int]],
+    hjc_race_summary: dict[str, dict[str, int]],
+) -> dict[str, Any]:
+    requested_keys = {(record.race_key, record.horse_number) for record in bundle.input_records}
+    bet_keys = {
+        (record.race_key, record.horse_number)
+        for record in bundle.decision_records
+        if record.bet_action == "bet"
+    }
+    race_key_order = tuple(sorted({record.race_key for record in bundle.input_records}))
+    requested_keys_by_race: dict[str, set[tuple[str, int]]] = {}
+    bet_keys_by_race: dict[str, set[tuple[str, int]]] = {}
+    for key in requested_keys:
+        requested_keys_by_race.setdefault(key[0], set()).add(key)
+    for key in bet_keys:
+        bet_keys_by_race.setdefault(key[0], set()).add(key)
+
+    race_summaries: list[dict[str, Any]] = []
+    for race_key in race_key_order:
+        requested_race_keys = requested_keys_by_race.get(race_key, set())
+        bet_race_keys = bet_keys_by_race.get(race_key, set())
+        matched_rows = {
+            key: row
+            for key, row in result_rows.items()
+            if key in requested_race_keys
+        }
+        known_result_count = sum(
+            1
+            for row in matched_rows.values()
+            if row.result_date is not None and row.finish_position is not None
+        )
+        bet_known_result_count = sum(
+            1
+            for key, row in matched_rows.items()
+            if key in bet_race_keys and row.result_date is not None and row.finish_position is not None
+        )
+        payout_match_count = sum(
+            1
+            for key, row in matched_rows.items()
+            if key in bet_race_keys and row.official_place_payout is not None
+        )
+        sed_summary = sed_race_summary.get(race_key, {})
+        hjc_summary = hjc_race_summary.get(race_key, {})
+        hjc_row_present = int(hjc_summary.get("hjc_rows_found", 0)) > 0
+        if known_result_count == len(requested_race_keys) and hjc_row_present:
+            race_recommendation = RESULT_DB_AVAILABILITY_SHOULD_SETTLE
+        elif known_result_count == 0 and int(sed_summary.get("sed_rows_found", 0)) == 0:
+            race_recommendation = RESULT_DB_AVAILABILITY_EXPECTED_PENDING_OR_STALE_DB
+        elif known_result_count == len(requested_race_keys) and not hjc_row_present:
+            race_recommendation = RESULT_DB_AVAILABILITY_INCOMPLETE_PAYOUT_SIDE
+        else:
+            race_recommendation = RESULT_DB_AVAILABILITY_PARTIAL_RESULTS
+        race_summaries.append(
+            {
+                "race_key": race_key,
+                "requested_records": len(requested_race_keys),
+                "requested_bets": len(bet_race_keys),
+                "sed_rows_found": int(sed_summary.get("sed_rows_found", 0)),
+                "known_result_rows": known_result_count,
+                "hjc_row_present": hjc_row_present,
+                "payout_rows_found": int(hjc_summary.get("payout_rows_found", 0)),
+                "bet_records_with_known_results": bet_known_result_count,
+                "bet_records_with_payout_rows": payout_match_count,
+                "recommendation": race_recommendation,
+            }
+        )
+
+    requested_records_with_known_results = sum(
+        1
+        for key in requested_keys
+        if (row := result_rows.get(key)) is not None
+        and row.result_date is not None
+        and row.finish_position is not None
+    )
+    requested_bets_with_known_results = sum(
+        1
+        for key in bet_keys
+        if (row := result_rows.get(key)) is not None
+        and row.result_date is not None
+        and row.finish_position is not None
+    )
+    races_with_sed_rows = sum(1 for race_key in race_key_order if race_key in sed_race_summary)
+    races_with_hjc_rows = sum(
+        1 for race_key in race_key_order if int(hjc_race_summary.get(race_key, {}).get("hjc_rows_found", 0)) > 0
+    )
+    all_results_known = requested_records_with_known_results == len(requested_keys)
+    all_hjc_present = races_with_hjc_rows == len(race_key_order)
+    if all_results_known and all_hjc_present:
+        recommendation = RESULT_DB_AVAILABILITY_SHOULD_SETTLE
+        recommendation_reason = (
+            "all requested records have known finish results and payout-side rows exist for each race"
+        )
+    elif requested_records_with_known_results == 0 and races_with_sed_rows == 0:
+        recommendation = RESULT_DB_AVAILABILITY_EXPECTED_PENDING_OR_STALE_DB
+        recommendation_reason = (
+            "none of the unit races are present in jrdb_sed_staging yet, so pending is still expected or the DB is stale"
+        )
+    elif all_results_known and not all_hjc_present:
+        recommendation = RESULT_DB_AVAILABILITY_INCOMPLETE_PAYOUT_SIDE
+        recommendation_reason = (
+            "finish results are present for all requested records, but payout-side rows are still missing for some races"
+        )
+    else:
+        recommendation = RESULT_DB_AVAILABILITY_PARTIAL_RESULTS
+        recommendation_reason = (
+            "some requested records are present in the result DB, but the unit does not look fully settled yet"
+        )
+
+    settled_as_of_assessment = "not_provided"
+    latest_known_result_date: str | None = None
+    if config.settled_as_of is not None:
+        known_result_dates = sorted(
+            {
+                row.result_date
+                for row in result_rows.values()
+                if row.result_date is not None
+            }
+        )
+        latest_known_result_date = known_result_dates[-1] if known_result_dates else None
+        if latest_known_result_date is None:
+            settled_as_of_assessment = "no_known_result_dates_in_db"
+        else:
+            settled_as_of_date = datetime.fromisoformat(config.settled_as_of).date()
+            latest_result_date = datetime.fromisoformat(f"{latest_known_result_date}T00:00:00+00:00").date()
+            if settled_as_of_date >= latest_result_date:
+                settled_as_of_assessment = "compatible_with_known_result_dates"
+            else:
+                settled_as_of_assessment = "earlier_than_latest_known_result_date"
+
+    return {
+        "run_name": config.name,
+        "checked_timestamp": datetime.now(timezone.utc).isoformat(),
+        "forward_output_dir": str(config.forward_output_dir),
+        "duckdb_path": str(config.duckdb_path),
+        "settled_as_of": config.settled_as_of,
+        "settled_as_of_assessment": settled_as_of_assessment,
+        "latest_known_result_date": latest_known_result_date,
+        "aggregate": {
+            "total_races": len(race_key_order),
+            "total_requested_records": len(requested_keys),
+            "total_requested_bets": len(bet_keys),
+            "races_with_sed_rows": races_with_sed_rows,
+            "races_with_hjc_rows": races_with_hjc_rows,
+            "requested_records_with_known_results": requested_records_with_known_results,
+            "requested_bets_with_known_results": requested_bets_with_known_results,
+        },
+        "recommendation": recommendation,
+        "recommendation_reason": recommendation_reason,
+        "race_summaries": race_summaries,
+    }
+
+
 def write_reconciliation_summary_text(*, path: Path, summary_payload: dict[str, Any]) -> None:
     lines = [
         f"place forward-test reconciliation summary: {summary_payload['run_name']}",
@@ -454,6 +757,41 @@ def write_reconciliation_summary_text(*, path: Path, summary_payload: dict[str, 
     )
     for status in sorted(summary_payload["reconciliation_status_counts"]):
         lines.append(f"- {status}: {summary_payload['reconciliation_status_counts'][status]}")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def write_result_availability_summary_text(*, path: Path, summary_payload: dict[str, Any]) -> None:
+    aggregate = summary_payload["aggregate"]
+    lines = [
+        f"place forward-test result availability check: {summary_payload['run_name']}",
+        "",
+        f"recommendation: {summary_payload['recommendation']}",
+        f"recommendation_reason: {summary_payload['recommendation_reason']}",
+        f"settled_as_of: {summary_payload['settled_as_of']}",
+        f"settled_as_of_assessment: {summary_payload['settled_as_of_assessment']}",
+        f"latest_known_result_date: {summary_payload['latest_known_result_date']}",
+        "",
+        f"total_races: {aggregate['total_races']}",
+        f"total_requested_records: {aggregate['total_requested_records']}",
+        f"total_requested_bets: {aggregate['total_requested_bets']}",
+        f"races_with_sed_rows: {aggregate['races_with_sed_rows']}",
+        f"races_with_hjc_rows: {aggregate['races_with_hjc_rows']}",
+        f"requested_records_with_known_results: {aggregate['requested_records_with_known_results']}",
+        f"requested_bets_with_known_results: {aggregate['requested_bets_with_known_results']}",
+        "",
+        "Race summaries",
+    ]
+    for race_summary in summary_payload["race_summaries"]:
+        lines.append(
+            "- "
+            f"{race_summary['race_key']}: requested_records={race_summary['requested_records']} "
+            f"requested_bets={race_summary['requested_bets']} "
+            f"sed_rows_found={race_summary['sed_rows_found']} "
+            f"known_result_rows={race_summary['known_result_rows']} "
+            f"hjc_row_present={race_summary['hjc_row_present']} "
+            f"bet_records_with_payout_rows={race_summary['bet_records_with_payout_rows']} "
+            f"recommendation={race_summary['recommendation']}"
+        )
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 

--- a/src/horse_bet_lab/forward_test/result_db_availability_cli.py
+++ b/src/horse_bet_lab/forward_test/result_db_availability_cli.py
@@ -1,0 +1,20 @@
+from horse_bet_lab.forward_test.reconciliation import (
+    build_result_db_availability_parser,
+    load_reconciliation_config,
+    run_place_forward_result_db_availability_check,
+)
+
+
+def main() -> None:
+    args = build_result_db_availability_parser().parse_args()
+    config = load_reconciliation_config(args.config)
+    result = run_place_forward_result_db_availability_check(config)
+    print(
+        "Place forward-test result DB availability check completed: "
+        f"name={result.run_name} recommendation={result.recommendation} "
+        f"total_races={result.total_races} output_dir={result.output_dir}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_place_forward_test_result_db_availability.py
+++ b/tests/test_place_forward_test_result_db_availability.py
@@ -1,0 +1,398 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import duckdb
+
+from horse_bet_lab.features.provenance import FEATURE_CONTRACT_VERSION
+from horse_bet_lab.forward_test.contracts import (
+    PLACE_FORWARD_TEST_INPUT_SCHEMA_VERSION,
+    PLACE_FORWARD_TEST_OUTPUT_SCHEMA_VERSION,
+    PlaceForwardBetDecisionRecord,
+    PlaceForwardInputRecord,
+    PlaceForwardPredictionOutputRecord,
+)
+from horse_bet_lab.forward_test.reconciliation import (
+    RESULT_DB_AVAILABILITY_EXPECTED_PENDING_OR_STALE_DB,
+    RESULT_DB_AVAILABILITY_INCOMPLETE_PAYOUT_SIDE,
+    RESULT_DB_AVAILABILITY_PARTIAL_RESULTS,
+    RESULT_DB_AVAILABILITY_SHOULD_SETTLE,
+    load_reconciliation_config,
+    run_place_forward_result_db_availability_check,
+    write_csv_records,
+    write_json_records,
+)
+
+
+def create_forward_output_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    input_records = (
+        PlaceForwardInputRecord(
+            race_key="11111111",
+            horse_number=1,
+            win_odds=2.0,
+            place_basis_odds=1.7,
+            popularity=None,
+            odds_observation_timestamp="2026-04-19T10:00:00+09:00",
+            input_source_name="operator_csv",
+            input_source_url=None,
+            input_source_timestamp="2026-04-19T09:59:00+09:00",
+            carrier_identity="place_forward_live_snapshot_v1",
+            snapshot_status="ok",
+            retry_count=1,
+            timeout_seconds=15.0,
+            snapshot_failure_reason=None,
+        ),
+        PlaceForwardInputRecord(
+            race_key="11111111",
+            horse_number=2,
+            win_odds=8.0,
+            place_basis_odds=2.5,
+            popularity=None,
+            odds_observation_timestamp="2026-04-19T10:00:00+09:00",
+            input_source_name="operator_csv",
+            input_source_url=None,
+            input_source_timestamp="2026-04-19T09:59:00+09:00",
+            carrier_identity="place_forward_live_snapshot_v1",
+            snapshot_status="ok",
+            retry_count=1,
+            timeout_seconds=15.0,
+            snapshot_failure_reason=None,
+        ),
+        PlaceForwardInputRecord(
+            race_key="22222222",
+            horse_number=1,
+            win_odds=3.0,
+            place_basis_odds=1.9,
+            popularity=None,
+            odds_observation_timestamp="2026-04-19T11:00:00+09:00",
+            input_source_name="operator_csv",
+            input_source_url=None,
+            input_source_timestamp="2026-04-19T10:59:00+09:00",
+            carrier_identity="place_forward_live_snapshot_v1",
+            snapshot_status="ok",
+            retry_count=1,
+            timeout_seconds=15.0,
+            snapshot_failure_reason=None,
+        ),
+    )
+    prediction_records = (
+        PlaceForwardPredictionOutputRecord(
+            race_key="11111111",
+            horse_number=1,
+            prediction_probability=0.61,
+            model_version="odds_only_logreg@phase1-test",
+            feature_contract_version=FEATURE_CONTRACT_VERSION,
+            carrier_identity="place_forward_live_snapshot_v1",
+            odds_observation_timestamp="2026-04-19T10:00:00+09:00",
+            input_schema_version=PLACE_FORWARD_TEST_INPUT_SCHEMA_VERSION,
+            output_schema_version=PLACE_FORWARD_TEST_OUTPUT_SCHEMA_VERSION,
+        ),
+        PlaceForwardPredictionOutputRecord(
+            race_key="11111111",
+            horse_number=2,
+            prediction_probability=0.31,
+            model_version="odds_only_logreg@phase1-test",
+            feature_contract_version=FEATURE_CONTRACT_VERSION,
+            carrier_identity="place_forward_live_snapshot_v1",
+            odds_observation_timestamp="2026-04-19T10:00:00+09:00",
+            input_schema_version=PLACE_FORWARD_TEST_INPUT_SCHEMA_VERSION,
+            output_schema_version=PLACE_FORWARD_TEST_OUTPUT_SCHEMA_VERSION,
+        ),
+        PlaceForwardPredictionOutputRecord(
+            race_key="22222222",
+            horse_number=1,
+            prediction_probability=0.44,
+            model_version="odds_only_logreg@phase1-test",
+            feature_contract_version=FEATURE_CONTRACT_VERSION,
+            carrier_identity="place_forward_live_snapshot_v1",
+            odds_observation_timestamp="2026-04-19T11:00:00+09:00",
+            input_schema_version=PLACE_FORWARD_TEST_INPUT_SCHEMA_VERSION,
+            output_schema_version=PLACE_FORWARD_TEST_OUTPUT_SCHEMA_VERSION,
+        ),
+    )
+    decision_records = (
+        PlaceForwardBetDecisionRecord(
+            race_key="11111111",
+            horse_number=1,
+            bet_action="bet",
+            decision_reason="selected by current baseline logic",
+            no_bet_reason=None,
+            feature_contract_version=FEATURE_CONTRACT_VERSION,
+            model_version="odds_only_logreg@phase1-test",
+            carrier_identity="place_forward_live_snapshot_v1",
+            odds_observation_timestamp="2026-04-19T10:00:00+09:00",
+            baseline_logic_id="guard_0_01_plus_proxy_domain_overlay",
+            fallback_logic_id="no_bet_guard_stronger",
+        ),
+        PlaceForwardBetDecisionRecord(
+            race_key="11111111",
+            horse_number=2,
+            bet_action="bet",
+            decision_reason="selected by current baseline logic",
+            no_bet_reason=None,
+            feature_contract_version=FEATURE_CONTRACT_VERSION,
+            model_version="odds_only_logreg@phase1-test",
+            carrier_identity="place_forward_live_snapshot_v1",
+            odds_observation_timestamp="2026-04-19T10:00:00+09:00",
+            baseline_logic_id="guard_0_01_plus_proxy_domain_overlay",
+            fallback_logic_id="no_bet_guard_stronger",
+        ),
+        PlaceForwardBetDecisionRecord(
+            race_key="22222222",
+            horse_number=1,
+            bet_action="no_bet",
+            decision_reason="dropped by guard_0_01 edge surcharge before overlay",
+            no_bet_reason="logic_filtered",
+            feature_contract_version=FEATURE_CONTRACT_VERSION,
+            model_version="odds_only_logreg@phase1-test",
+            carrier_identity="place_forward_live_snapshot_v1",
+            odds_observation_timestamp="2026-04-19T11:00:00+09:00",
+            baseline_logic_id="guard_0_01_plus_proxy_domain_overlay",
+            fallback_logic_id="no_bet_guard_stronger",
+        ),
+    )
+    write_csv_records(path / "input_snapshot_records.csv", input_records)
+    write_json_records(path / "input_snapshot_records.json", input_records)
+    write_csv_records(path / "prediction_output_records.csv", prediction_records)
+    write_json_records(path / "prediction_output_records.json", prediction_records)
+    write_csv_records(path / "bet_decision_records.csv", decision_records)
+    write_json_records(path / "bet_decision_records.json", decision_records)
+    (path / "run_manifest.json").write_text(
+        json.dumps(
+            {
+                "run_name": "phase1_forward_test",
+                "run_timestamp": "2026-04-19T03:00:00+00:00",
+                "input_schema_version": "place_forward_test_input_v1",
+                "record_counts": {
+                    "input_records": 3,
+                    "prediction_records": 3,
+                    "decision_records": 3,
+                },
+                "bet_logic": {
+                    "stake_per_bet": 100.0,
+                    "candidate_logic_id": "guard_0_01_plus_proxy_domain_overlay",
+                    "fallback_logic_id": "no_bet_guard_stronger",
+                },
+                "model_lineage": {
+                    "model_version": "odds_only_logreg@phase1-test",
+                },
+                "provenance": {
+                    "model_feature_columns": ["win_odds"],
+                },
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+
+def create_result_duckdb_ready(path: Path) -> None:
+    connection = duckdb.connect(str(path))
+    try:
+        connection.execute(
+            """
+            CREATE TABLE jrdb_sed_staging (
+                race_key VARCHAR,
+                horse_number INTEGER,
+                result_date DATE,
+                finish_position INTEGER
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO jrdb_sed_staging VALUES
+                ('11111111', 1, DATE '2026-04-20', 1),
+                ('11111111', 2, DATE '2026-04-20', 5),
+                ('22222222', 1, DATE '2026-04-21', 2)
+            """
+        )
+        connection.execute(
+            """
+            CREATE TABLE jrdb_hjc_staging (
+                race_key VARCHAR,
+                place_horse_number_1 INTEGER,
+                place_payout_1 DOUBLE,
+                place_horse_number_2 INTEGER,
+                place_payout_2 DOUBLE,
+                place_horse_number_3 INTEGER,
+                place_payout_3 DOUBLE
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO jrdb_hjc_staging VALUES
+                ('11111111', 1, 180.0, 3, 220.0, 4, 150.0),
+                ('22222222', 1, 210.0, 4, 170.0, 6, 160.0)
+            """
+        )
+    finally:
+        connection.close()
+
+
+def create_result_duckdb_partial(path: Path) -> None:
+    connection = duckdb.connect(str(path))
+    try:
+        connection.execute(
+            """
+            CREATE TABLE jrdb_sed_staging (
+                race_key VARCHAR,
+                horse_number INTEGER,
+                result_date DATE,
+                finish_position INTEGER
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO jrdb_sed_staging VALUES
+                ('11111111', 1, DATE '2026-04-20', 1),
+                ('11111111', 2, DATE '2026-04-20', 5)
+            """
+        )
+        connection.execute(
+            """
+            CREATE TABLE jrdb_hjc_staging (
+                race_key VARCHAR,
+                place_horse_number_1 INTEGER,
+                place_payout_1 DOUBLE,
+                place_horse_number_2 INTEGER,
+                place_payout_2 DOUBLE,
+                place_horse_number_3 INTEGER,
+                place_payout_3 DOUBLE
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO jrdb_hjc_staging VALUES
+                ('11111111', 1, 180.0, 3, 220.0, 4, 150.0)
+            """
+        )
+    finally:
+        connection.close()
+
+
+def create_result_duckdb_missing_hjc(path: Path) -> None:
+    connection = duckdb.connect(str(path))
+    try:
+        connection.execute(
+            """
+            CREATE TABLE jrdb_sed_staging (
+                race_key VARCHAR,
+                horse_number INTEGER,
+                result_date DATE,
+                finish_position INTEGER
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO jrdb_sed_staging VALUES
+                ('11111111', 1, DATE '2026-04-20', 1),
+                ('11111111', 2, DATE '2026-04-20', 5),
+                ('22222222', 1, DATE '2026-04-21', 2)
+            """
+        )
+        connection.execute(
+            """
+            CREATE TABLE jrdb_hjc_staging (
+                race_key VARCHAR,
+                place_horse_number_1 INTEGER,
+                place_payout_1 DOUBLE,
+                place_horse_number_2 INTEGER,
+                place_payout_2 DOUBLE,
+                place_horse_number_3 INTEGER,
+                place_payout_3 DOUBLE
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO jrdb_hjc_staging VALUES
+                ('11111111', 1, 180.0, 3, 220.0, 4, 150.0)
+            """
+        )
+    finally:
+        connection.close()
+
+
+def write_reconciliation_config(path: Path, forward_output_dir: Path, duckdb_path: Path, output_dir: Path) -> None:
+    path.write_text(
+        (
+            "[place_forward_reconciliation]\n"
+            "name = 'phase1_forward_reconciliation'\n"
+            f"forward_output_dir = '{forward_output_dir}'\n"
+            f"duckdb_path = '{duckdb_path}'\n"
+            f"output_dir = '{output_dir}'\n"
+            "settled_as_of = '2026-04-21T09:00:00+09:00'\n"
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_result_db_availability_check_reports_should_settle(tmp_path: Path) -> None:
+    forward_output_dir = tmp_path / "forward_output"
+    duckdb_path = tmp_path / "results_ready.duckdb"
+    output_dir = tmp_path / "reconciliation_output"
+    config_path = tmp_path / "reconciliation.toml"
+
+    create_forward_output_dir(forward_output_dir)
+    create_result_duckdb_ready(duckdb_path)
+    write_reconciliation_config(config_path, forward_output_dir, duckdb_path, output_dir)
+
+    result = run_place_forward_result_db_availability_check(load_reconciliation_config(config_path))
+
+    assert result.recommendation == RESULT_DB_AVAILABILITY_SHOULD_SETTLE
+    payload = json.loads((output_dir / "result_availability_check.json").read_text(encoding="utf-8"))
+    assert payload["aggregate"]["total_races"] == 2
+    assert payload["aggregate"]["requested_records_with_known_results"] == 3
+    assert payload["aggregate"]["races_with_hjc_rows"] == 2
+    assert payload["settled_as_of_assessment"] == "compatible_with_known_result_dates"
+    assert any(
+        race_summary["recommendation"] == RESULT_DB_AVAILABILITY_SHOULD_SETTLE
+        for race_summary in payload["race_summaries"]
+    )
+    assert (output_dir / "result_availability_check.txt").exists()
+
+
+def test_result_db_availability_check_reports_partial_results(tmp_path: Path) -> None:
+    forward_output_dir = tmp_path / "forward_output"
+    duckdb_path = tmp_path / "results_partial.duckdb"
+    output_dir = tmp_path / "reconciliation_output"
+    config_path = tmp_path / "reconciliation.toml"
+
+    create_forward_output_dir(forward_output_dir)
+    create_result_duckdb_partial(duckdb_path)
+    write_reconciliation_config(config_path, forward_output_dir, duckdb_path, output_dir)
+
+    result = run_place_forward_result_db_availability_check(load_reconciliation_config(config_path))
+
+    assert result.recommendation == RESULT_DB_AVAILABILITY_PARTIAL_RESULTS
+    payload = json.loads((output_dir / "result_availability_check.json").read_text(encoding="utf-8"))
+    assert payload["aggregate"]["races_with_sed_rows"] == 1
+    assert payload["aggregate"]["requested_records_with_known_results"] == 2
+    race_222 = next(row for row in payload["race_summaries"] if row["race_key"] == "22222222")
+    assert race_222["recommendation"] == RESULT_DB_AVAILABILITY_EXPECTED_PENDING_OR_STALE_DB
+
+
+def test_result_db_availability_check_reports_missing_payout_side(tmp_path: Path) -> None:
+    forward_output_dir = tmp_path / "forward_output"
+    duckdb_path = tmp_path / "results_missing_hjc.duckdb"
+    output_dir = tmp_path / "reconciliation_output"
+    config_path = tmp_path / "reconciliation.toml"
+
+    create_forward_output_dir(forward_output_dir)
+    create_result_duckdb_missing_hjc(duckdb_path)
+    write_reconciliation_config(config_path, forward_output_dir, duckdb_path, output_dir)
+
+    result = run_place_forward_result_db_availability_check(load_reconciliation_config(config_path))
+
+    assert result.recommendation == RESULT_DB_AVAILABILITY_INCOMPLETE_PAYOUT_SIDE
+    payload = json.loads((output_dir / "result_availability_check.json").read_text(encoding="utf-8"))
+    assert payload["aggregate"]["races_with_hjc_rows"] == 1
+    race_222 = next(row for row in payload["race_summaries"] if row["race_key"] == "22222222")
+    assert race_222["recommendation"] == RESULT_DB_AVAILABILITY_INCOMPLETE_PAYOUT_SIDE


### PR DESCRIPTION
## Summary
- add a thin operator aid that checks result DB availability before reconciliation
- surface whether a run unit looks ready to settle or still looks pending/stale on the DB side
- write a small availability summary next to reconciliation artifacts
- update runbooks so operators run the availability check before reconciliation
- keep current hard-adopt baseline, BET logic, and frozen carrier decisions unchanged

## Included commit
- `2bded2c` — `add thin operator aid for place forward-test result DB availability check`

## Scope
- `src/horse_bet_lab/forward_test/reconciliation.py`
- `src/horse_bet_lab/forward_test/result_db_availability_cli.py`
- `src/horse_bet_lab/forward_test/__init__.py`
- `tests/test_place_forward_test_result_db_availability.py`
- `docs/runbooks/place_forward_test_phase1_runbook.md`
- `docs/runbooks/place_forward_test_phase1_recurring_rehearsal.md`

## What this adds
### Availability check
- CLI entrypoint:
  - `PYTHONPATH=src .venv/bin/python -m horse_bet_lab.forward_test.result_db_availability_cli --config configs/recurring_rehearsal/<unit_id>.reconciliation.toml`

### Output
- `<reconciliation output dir>/result_availability_check.json`
- `<reconciliation output dir>/result_availability_check.txt`

### What it reports
- race presence in `jrdb_sed_staging`
- known result-row counts
- payout-side presence in `jrdb_hjc_staging`
- `settled_as_of` assessment
- recommendation:
  - `should_settle`
  - `expected_pending_or_stale_db`
  - `result_db_partial_results`
  - `result_db_incomplete_payout_side`

## Validation
- `PYTHONPATH=src .venv/bin/python -m pytest tests/test_place_forward_test_scaffold.py tests/test_place_forward_test_result_db_availability.py`
- `PYTHONPATH=src .venv/bin/python -m horse_bet_lab.forward_test.result_db_availability_cli --help`
- `PYTHONPATH=src .venv/bin/python -m horse_bet_lab.forward_test.result_db_availability_cli --config configs/recurring_rehearsal/20260419_satsuki_sho_pass2.reconciliation.toml`

## What this does NOT change
- no reconciliation settlement logic rewrite
- no BET logic changes
- no baseline rewrite
- no threshold / surcharge / guard changes
- no popularity carrier resolution
- no frozen `win_odds` migration retry
- no DuckDB auto-update

## Remaining manual steps
- operator still supplies `settled_as_of`
- operator still confirms DB freshness externally
- next step is to observe whether this check actually reduces recurring hesitation across more weeks