### PR TITLE
add thin operator aid for place forward-test result DB freshness confirmation

### DIFF
--- a/docs/runbooks/place_forward_test_phase1_recurring_rehearsal.md
+++ b/docs/runbooks/place_forward_test_phase1_recurring_rehearsal.md
@@ -99,10 +99,11 @@ data/forward_test/runs/<unit_id>/notes/
 1. scaffold が生成した reconciliation config の `duckdb_path` / `settled_as_of` を確認する
 2. reconciliation 前に result DB availability check を実行する
 3. `result_availability_check.txt` を見て、`should_settle` か `expected_pending_or_stale_db` かを確認する
-4. reconciliation を実行する
-5. `reconciled_records.csv` を確認する
-6. `reconciliation_summary.json` を確認する
-7. `settled_hit`, `settled_miss`, `settled_no_bet`, `unsettled_*` の件数を確認する
+4. `expected_pending_or_stale_db` のときは `DB freshness summary` の `result_side_freshness_vs_settled_as_of` / `payout_side_freshness_vs_settled_as_of` / `operator_freshness_hint` を見る
+5. reconciliation を実行する
+6. `reconciled_records.csv` を確認する
+7. `reconciliation_summary.json` を確認する
+8. `settled_hit`, `settled_miss`, `settled_no_bet`, `unsettled_*` の件数を確認する
 
 ### Weekly / periodic checklist
 
@@ -145,6 +146,7 @@ data/forward_test/runs/<unit_id>/notes/
 - `unsettled_result_pending`, `unsettled_result_incomplete`
   - まだ結果確認が閉じていない
   - reconciliation 前に `result_availability_check` で `expected_pending_or_stale_db` や `result_db_partial_results` が出ていれば、operator 手順ミスではなく result DB freshness の問題を先に疑う
+  - とくに `operator_freshness_hint = local_result_db_may_be_stale_for_this_reconciliation_window` なら local DuckDB 側の鮮度を先に確認する
 
 ## Template Files
 

--- a/docs/runbooks/place_forward_test_phase1_runbook.md
+++ b/docs/runbooks/place_forward_test_phase1_runbook.md
@@ -201,8 +201,9 @@ PYTHONPATH=src .venv/bin/python -m horse_bet_lab.forward_test.reconciliation_cli
 7. レース結果が確定したら reconciliation config を用意する
 8. result DB availability check を実行する
 9. `result_availability_check.txt` / `.json` を見て `should_settle` か `expected_pending_or_stale_db` かを確認する
-10. reconciliation を実行する
-11. `reconciled_records.csv` と `reconciliation_summary.json` を確認する
+10. `expected_pending_or_stale_db` のときは `DB freshness summary` を見て、`result_side_freshness_vs_settled_as_of` と `operator_freshness_hint` を先に読む
+11. reconciliation を実行する
+12. `reconciled_records.csv` と `reconciliation_summary.json` を確認する
 
 operator rehearsal で最短確認したい点:
 
@@ -223,6 +224,15 @@ post-race reconciliation 例:
 PYTHONPATH=src .venv/bin/python -m horse_bet_lab.forward_test.result_db_availability_cli --config configs/place_forward_test_reconciliation.sample.toml
 PYTHONPATH=src .venv/bin/python -m horse_bet_lab.forward_test.reconciliation_cli --config configs/place_forward_test_reconciliation.sample.toml
 ```
+
+availability check の読み方:
+
+- `result_side_freshness_vs_settled_as_of = result_side_behind_settled_as_of`
+  - local DuckDB が今回の reconciliation window に追いついていない可能性を先に疑う
+- `result_side_freshness_vs_settled_as_of = result_side_covers_settled_as_of`
+  - DB 全体は window をカバーしているので、target race missing / partial loading を疑う
+- `payout_side_freshness_vs_settled_as_of = payout_side_behind_settled_as_of`
+  - finish result は見えていても payout side の反映待ちの可能性がある
 
 end-to-end operator rehearsal 例:
 

--- a/src/horse_bet_lab/forward_test/reconciliation.py
+++ b/src/horse_bet_lab/forward_test/reconciliation.py
@@ -204,12 +204,14 @@ def run_place_forward_result_db_availability_check(
         duckdb_path=config.duckdb_path,
         race_keys=race_keys,
     )
+    db_freshness_summary = load_result_db_freshness_summary(duckdb_path=config.duckdb_path)
     payload = build_result_availability_summary_payload(
         config=config,
         bundle=bundle,
         result_rows=result_rows,
         sed_race_summary=sed_race_summary,
         hjc_race_summary=hjc_race_summary,
+        db_freshness_summary=db_freshness_summary,
     )
     summary_json_path = config.output_dir / "result_availability_check.json"
     summary_json_path.write_text(
@@ -413,6 +415,98 @@ def load_result_availability_race_summary(
     return sed_output, hjc_output
 
 
+def load_result_db_freshness_summary(*, duckdb_path: Path) -> dict[str, Any]:
+    connection = duckdb.connect(str(duckdb_path), read_only=True)
+    try:
+        latest_sed_result_date = connection.execute(
+            """
+            SELECT CAST(MAX(result_date) AS VARCHAR)
+            FROM jrdb_sed_staging
+            WHERE result_date IS NOT NULL
+            """
+        ).fetchone()[0]
+        sed_races_on_latest_result_date = 0
+        if latest_sed_result_date is not None:
+            sed_races_on_latest_result_date = int(
+                connection.execute(
+                    """
+                    SELECT COUNT(DISTINCT race_key)
+                    FROM jrdb_sed_staging
+                    WHERE result_date = CAST(? AS DATE)
+                    """,
+                    [latest_sed_result_date],
+                ).fetchone()[0]
+                or 0
+            )
+        total_sed_races = int(
+            connection.execute(
+                """
+                SELECT COUNT(DISTINCT race_key)
+                FROM jrdb_sed_staging
+                """
+            ).fetchone()[0]
+            or 0
+        )
+
+        latest_hjc_result_date = connection.execute(
+            """
+            WITH hjc_race_dates AS (
+                SELECT
+                    h.race_key,
+                    MAX(s.result_date) AS result_date
+                FROM jrdb_hjc_staging h
+                LEFT JOIN jrdb_sed_staging s
+                    ON h.race_key = s.race_key
+                GROUP BY h.race_key
+            )
+            SELECT CAST(MAX(result_date) AS VARCHAR)
+            FROM hjc_race_dates
+            WHERE result_date IS NOT NULL
+            """
+        ).fetchone()[0]
+        hjc_races_on_latest_result_date = 0
+        if latest_hjc_result_date is not None:
+            hjc_races_on_latest_result_date = int(
+                connection.execute(
+                    """
+                    WITH hjc_race_dates AS (
+                        SELECT
+                            h.race_key,
+                            MAX(s.result_date) AS result_date
+                        FROM jrdb_hjc_staging h
+                        LEFT JOIN jrdb_sed_staging s
+                            ON h.race_key = s.race_key
+                        GROUP BY h.race_key
+                    )
+                    SELECT COUNT(*)
+                    FROM hjc_race_dates
+                    WHERE result_date = CAST(? AS DATE)
+                    """,
+                    [latest_hjc_result_date],
+                ).fetchone()[0]
+                or 0
+            )
+        total_hjc_races = int(
+            connection.execute(
+                """
+                SELECT COUNT(DISTINCT race_key)
+                FROM jrdb_hjc_staging
+                """
+            ).fetchone()[0]
+            or 0
+        )
+    finally:
+        connection.close()
+    return {
+        "latest_sed_result_date": str(latest_sed_result_date) if latest_sed_result_date is not None else None,
+        "sed_races_on_latest_result_date": sed_races_on_latest_result_date,
+        "total_sed_races": total_sed_races,
+        "latest_hjc_result_date": str(latest_hjc_result_date) if latest_hjc_result_date is not None else None,
+        "hjc_races_on_latest_result_date": hjc_races_on_latest_result_date,
+        "total_hjc_races": total_hjc_races,
+    }
+
+
 def reconcile_forward_records(
     *,
     bundle: ForwardArtifactBundle,
@@ -577,6 +671,7 @@ def build_result_availability_summary_payload(
     result_rows: dict[tuple[str, int], PlaceForwardResultRecord],
     sed_race_summary: dict[str, dict[str, int]],
     hjc_race_summary: dict[str, dict[str, int]],
+    db_freshness_summary: dict[str, Any],
 ) -> dict[str, Any]:
     requested_keys = {(record.race_key, record.horse_number) for record in bundle.input_records}
     bet_keys = {
@@ -685,6 +780,11 @@ def build_result_availability_summary_payload(
 
     settled_as_of_assessment = "not_provided"
     latest_known_result_date: str | None = None
+    unit_latest_observation_timestamp = max(record.odds_observation_timestamp for record in bundle.input_records)
+    unit_latest_observation_date = datetime.fromisoformat(unit_latest_observation_timestamp).date().isoformat()
+    result_side_freshness = "settled_as_of_not_provided"
+    payout_side_freshness = "settled_as_of_not_provided"
+    operator_freshness_hint = "provide_settled_as_of_to_compare_db_coverage"
     if config.settled_as_of is not None:
         known_result_dates = sorted(
             {
@@ -703,6 +803,21 @@ def build_result_availability_summary_payload(
                 settled_as_of_assessment = "compatible_with_known_result_dates"
             else:
                 settled_as_of_assessment = "earlier_than_latest_known_result_date"
+        result_side_freshness = assess_result_db_freshness_against_settled_as_of(
+            latest_result_date=db_freshness_summary.get("latest_sed_result_date"),
+            settled_as_of=config.settled_as_of,
+            prefix="result_side",
+        )
+        payout_side_freshness = assess_result_db_freshness_against_settled_as_of(
+            latest_result_date=db_freshness_summary.get("latest_hjc_result_date"),
+            settled_as_of=config.settled_as_of,
+            prefix="payout_side",
+        )
+        operator_freshness_hint = build_result_db_operator_freshness_hint(
+            recommendation=recommendation,
+            result_side_freshness=result_side_freshness,
+            payout_side_freshness=payout_side_freshness,
+        )
 
     return {
         "run_name": config.name,
@@ -712,6 +827,14 @@ def build_result_availability_summary_payload(
         "settled_as_of": config.settled_as_of,
         "settled_as_of_assessment": settled_as_of_assessment,
         "latest_known_result_date": latest_known_result_date,
+        "db_freshness_summary": {
+            **db_freshness_summary,
+            "unit_latest_observation_timestamp": unit_latest_observation_timestamp,
+            "unit_latest_observation_date": unit_latest_observation_date,
+            "result_side_freshness_vs_settled_as_of": result_side_freshness,
+            "payout_side_freshness_vs_settled_as_of": payout_side_freshness,
+            "operator_freshness_hint": operator_freshness_hint,
+        },
         "aggregate": {
             "total_races": len(race_key_order),
             "total_requested_records": len(requested_keys),
@@ -725,6 +848,47 @@ def build_result_availability_summary_payload(
         "recommendation_reason": recommendation_reason,
         "race_summaries": race_summaries,
     }
+
+
+def assess_result_db_freshness_against_settled_as_of(
+    *,
+    latest_result_date: str | None,
+    settled_as_of: str | None,
+    prefix: str,
+) -> str:
+    if settled_as_of is None:
+        return "settled_as_of_not_provided"
+    if latest_result_date is None:
+        return f"no_known_{prefix}_dates_in_db"
+    settled_as_of_date = datetime.fromisoformat(settled_as_of).date()
+    latest_date = datetime.fromisoformat(f"{latest_result_date}T00:00:00+00:00").date()
+    if latest_date < settled_as_of_date:
+        return f"{prefix}_behind_settled_as_of"
+    return f"{prefix}_covers_settled_as_of"
+
+
+def build_result_db_operator_freshness_hint(
+    *,
+    recommendation: str,
+    result_side_freshness: str,
+    payout_side_freshness: str,
+) -> str:
+    if result_side_freshness == "settled_as_of_not_provided":
+        return "provide_settled_as_of_to_compare_db_coverage"
+    if result_side_freshness == "no_known_result_side_dates_in_db":
+        return "db_has_no_known_result_dates_yet"
+    if result_side_freshness == "result_side_behind_settled_as_of":
+        return "local_result_db_may_be_stale_for_this_reconciliation_window"
+    if (
+        recommendation == RESULT_DB_AVAILABILITY_EXPECTED_PENDING_OR_STALE_DB
+        and result_side_freshness == "result_side_covers_settled_as_of"
+    ):
+        return "result_side_covers_settled_as_of_but_target_race_is_still_missing"
+    if payout_side_freshness == "payout_side_behind_settled_as_of":
+        return "finish_results_reach_settled_as_of_but_payout_side_may_still_be_behind"
+    if payout_side_freshness == "no_known_payout_side_dates_in_db":
+        return "payout_side_has_no_known_result_dates_yet"
+    return "db_coverage_looks_compatible_with_settled_as_of"
 
 
 def write_reconciliation_summary_text(*, path: Path, summary_payload: dict[str, Any]) -> None:
@@ -762,6 +926,7 @@ def write_reconciliation_summary_text(*, path: Path, summary_payload: dict[str, 
 
 def write_result_availability_summary_text(*, path: Path, summary_payload: dict[str, Any]) -> None:
     aggregate = summary_payload["aggregate"]
+    db_freshness_summary = summary_payload["db_freshness_summary"]
     lines = [
         f"place forward-test result availability check: {summary_payload['run_name']}",
         "",
@@ -770,6 +935,25 @@ def write_result_availability_summary_text(*, path: Path, summary_payload: dict[
         f"settled_as_of: {summary_payload['settled_as_of']}",
         f"settled_as_of_assessment: {summary_payload['settled_as_of_assessment']}",
         f"latest_known_result_date: {summary_payload['latest_known_result_date']}",
+        "",
+        "DB freshness summary",
+        f"unit_latest_observation_timestamp: {db_freshness_summary['unit_latest_observation_timestamp']}",
+        f"unit_latest_observation_date: {db_freshness_summary['unit_latest_observation_date']}",
+        f"latest_sed_result_date: {db_freshness_summary['latest_sed_result_date']}",
+        f"sed_races_on_latest_result_date: {db_freshness_summary['sed_races_on_latest_result_date']}",
+        f"total_sed_races: {db_freshness_summary['total_sed_races']}",
+        f"latest_hjc_result_date: {db_freshness_summary['latest_hjc_result_date']}",
+        f"hjc_races_on_latest_result_date: {db_freshness_summary['hjc_races_on_latest_result_date']}",
+        f"total_hjc_races: {db_freshness_summary['total_hjc_races']}",
+        (
+            "result_side_freshness_vs_settled_as_of: "
+            f"{db_freshness_summary['result_side_freshness_vs_settled_as_of']}"
+        ),
+        (
+            "payout_side_freshness_vs_settled_as_of: "
+            f"{db_freshness_summary['payout_side_freshness_vs_settled_as_of']}"
+        ),
+        f"operator_freshness_hint: {db_freshness_summary['operator_freshness_hint']}",
         "",
         f"total_races: {aggregate['total_races']}",
         f"total_requested_records: {aggregate['total_requested_records']}",

--- a/tests/test_place_forward_test_result_db_availability.py
+++ b/tests/test_place_forward_test_result_db_availability.py
@@ -320,6 +320,92 @@ def create_result_duckdb_missing_hjc(path: Path) -> None:
         connection.close()
 
 
+def create_result_duckdb_stale_for_settled_as_of(path: Path) -> None:
+    connection = duckdb.connect(str(path))
+    try:
+        connection.execute(
+            """
+            CREATE TABLE jrdb_sed_staging (
+                race_key VARCHAR,
+                horse_number INTEGER,
+                result_date DATE,
+                finish_position INTEGER
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO jrdb_sed_staging VALUES
+                ('11111111', 1, DATE '2026-04-20', 1),
+                ('11111111', 2, DATE '2026-04-20', 5)
+            """
+        )
+        connection.execute(
+            """
+            CREATE TABLE jrdb_hjc_staging (
+                race_key VARCHAR,
+                place_horse_number_1 INTEGER,
+                place_payout_1 DOUBLE,
+                place_horse_number_2 INTEGER,
+                place_payout_2 DOUBLE,
+                place_horse_number_3 INTEGER,
+                place_payout_3 DOUBLE
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO jrdb_hjc_staging VALUES
+                ('11111111', 1, 180.0, 3, 220.0, 4, 150.0)
+            """
+        )
+    finally:
+        connection.close()
+
+
+def create_result_duckdb_target_missing_but_db_fresh(path: Path) -> None:
+    connection = duckdb.connect(str(path))
+    try:
+        connection.execute(
+            """
+            CREATE TABLE jrdb_sed_staging (
+                race_key VARCHAR,
+                horse_number INTEGER,
+                result_date DATE,
+                finish_position INTEGER
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO jrdb_sed_staging VALUES
+                ('99999999', 1, DATE '2026-04-21', 1),
+                ('99999999', 2, DATE '2026-04-21', 5)
+            """
+        )
+        connection.execute(
+            """
+            CREATE TABLE jrdb_hjc_staging (
+                race_key VARCHAR,
+                place_horse_number_1 INTEGER,
+                place_payout_1 DOUBLE,
+                place_horse_number_2 INTEGER,
+                place_payout_2 DOUBLE,
+                place_horse_number_3 INTEGER,
+                place_payout_3 DOUBLE
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO jrdb_hjc_staging VALUES
+                ('99999999', 1, 180.0, 3, 220.0, 4, 150.0)
+            """
+        )
+    finally:
+        connection.close()
+
+
 def write_reconciliation_config(path: Path, forward_output_dir: Path, duckdb_path: Path, output_dir: Path) -> None:
     path.write_text(
         (
@@ -396,3 +482,44 @@ def test_result_db_availability_check_reports_missing_payout_side(tmp_path: Path
     assert payload["aggregate"]["races_with_hjc_rows"] == 1
     race_222 = next(row for row in payload["race_summaries"] if row["race_key"] == "22222222")
     assert race_222["recommendation"] == RESULT_DB_AVAILABILITY_INCOMPLETE_PAYOUT_SIDE
+
+
+def test_result_db_availability_check_reports_result_side_behind_settled_as_of(tmp_path: Path) -> None:
+    forward_output_dir = tmp_path / "forward_output"
+    duckdb_path = tmp_path / "results_stale.duckdb"
+    output_dir = tmp_path / "reconciliation_output"
+    config_path = tmp_path / "reconciliation.toml"
+
+    create_forward_output_dir(forward_output_dir)
+    create_result_duckdb_stale_for_settled_as_of(duckdb_path)
+    write_reconciliation_config(config_path, forward_output_dir, duckdb_path, output_dir)
+
+    run_place_forward_result_db_availability_check(load_reconciliation_config(config_path))
+
+    payload = json.loads((output_dir / "result_availability_check.json").read_text(encoding="utf-8"))
+    freshness = payload["db_freshness_summary"]
+    assert freshness["latest_sed_result_date"] == "2026-04-20"
+    assert freshness["result_side_freshness_vs_settled_as_of"] == "result_side_behind_settled_as_of"
+    assert freshness["operator_freshness_hint"] == "local_result_db_may_be_stale_for_this_reconciliation_window"
+    text_summary = (output_dir / "result_availability_check.txt").read_text(encoding="utf-8")
+    assert "operator_freshness_hint: local_result_db_may_be_stale_for_this_reconciliation_window" in text_summary
+
+
+def test_result_db_availability_check_reports_target_missing_despite_db_covering_window(tmp_path: Path) -> None:
+    forward_output_dir = tmp_path / "forward_output"
+    duckdb_path = tmp_path / "results_target_missing.duckdb"
+    output_dir = tmp_path / "reconciliation_output"
+    config_path = tmp_path / "reconciliation.toml"
+
+    create_forward_output_dir(forward_output_dir)
+    create_result_duckdb_target_missing_but_db_fresh(duckdb_path)
+    write_reconciliation_config(config_path, forward_output_dir, duckdb_path, output_dir)
+
+    result = run_place_forward_result_db_availability_check(load_reconciliation_config(config_path))
+
+    assert result.recommendation == RESULT_DB_AVAILABILITY_EXPECTED_PENDING_OR_STALE_DB
+    payload = json.loads((output_dir / "result_availability_check.json").read_text(encoding="utf-8"))
+    freshness = payload["db_freshness_summary"]
+    assert freshness["latest_sed_result_date"] == "2026-04-21"
+    assert freshness["result_side_freshness_vs_settled_as_of"] == "result_side_covers_settled_as_of"
+    assert freshness["operator_freshness_hint"] == "result_side_covers_settled_as_of_but_target_race_is_still_missing"


### PR DESCRIPTION
## Summary
- enrich the existing result DB availability check with DB-global freshness context
- help operators distinguish “expected pending” from “local DuckDB is likely behind”
- keep reconciliation settlement logic unchanged
- update runbooks so operators read DB freshness context before deciding whether to reconcile
- keep current hard-adopt baseline, BET logic, and frozen carrier decisions unchanged

## Scope
- `src/horse_bet_lab/forward_test/reconciliation.py`
- `tests/test_place_forward_test_result_db_availability.py`
- `docs/runbooks/place_forward_test_phase1_runbook.md`
- `docs/runbooks/place_forward_test_phase1_recurring_rehearsal.md`

## What this adds
The existing availability check output is extended with:
- `latest_sed_result_date`
- `latest_hjc_result_date`
- coverage counts on those latest dates
- `result_side_freshness_vs_settled_as_of`
- `payout_side_freshness_vs_settled_as_of`
- `operator_freshness_hint`

This gives the operator a better pre-reconciliation signal about whether:
- the target unit is simply not ready yet, or
- the local result DB is likely stale relative to `settled_as_of`

## Validation
- `PYTHONPATH=src .venv/bin/python -m pytest tests/test_place_forward_test_result_db_availability.py`
- `PYTHONPATH=src .venv/bin/python -m horse_bet_lab.forward_test.result_db_availability_cli --help`

## What this does NOT change
- no reconciliation settlement logic rewrite
- no BET logic changes
- no baseline rewrite
- no threshold / surcharge / guard changes
- no popularity carrier resolution
- no frozen `win_odds` migration retry
- no external freshness fetch
- no DuckDB auto-update