### PR TITLE
clarify popularity as non-mainline legacy carrier

### DIFF
--- a/docs/spec/feature_contract_v1.md
+++ b/docs/spec/feature_contract_v1.md
@@ -80,7 +80,8 @@ v1 では `model_feature_columns` は必ず dataset schema 上の feature 列の
 
 - feature の `availability timing` は「その値を正当に意思決定に使える最も早い時点」で判定する
 - ただし v1 では `historical carrier timing` も別途意識する
-- 今回の整理では `win_odds` だけを先行して pre-race carrier contract へ移し、`popularity` は未確認のため `legacy_sed_only` として残す
+- 今回の整理では `win_odds` だけを先行して pre-race carrier contract へ移し、`popularity` は未確認のため `legacy_sed_only_non_mainline` として残す
+- popularity carrier decision は `unresolved_keep_legacy_for_non-mainline_only` とする
 
 ### Leakage Prohibition
 
@@ -121,7 +122,7 @@ v1 では `model_feature_columns` は必ず dataset schema 上の feature 列の
 | feature | class | source | availability timing | train | eval | backtest | leakage risk | missing handling | notes |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | `win_odds` | upstream raw, market-derived | `jrdb_win_market_snapshot_v1.win_odds` | pre-race | allow | allow via provenance | allow | low-to-medium | carrier missing -> `NULL` | current carrier row is project-owned and populated from `OZ.win_basis_odds`; provenance carrier identity is `win_market_snapshot_v1` |
-| `popularity` | upstream raw, market-derived | `SED.popularity` | pre-race semantic, post-race carrier in current offline build | allow | allow via provenance | allow | medium | parse failure -> `NULL` | ordinal rank。pre-race carrier is not yet confirmed; provenance carrier identity is `legacy_sed_only` |
+| `popularity` | upstream raw, market-derived | `SED.popularity` | pre-race semantic, post-race carrier in current offline build | allow for legacy/research only | allow via provenance | allow for legacy/research only | medium | parse failure -> `NULL` | ordinal rank。pre-race carrier is not yet confirmed; provenance carrier identity is `legacy_sed_only_non_mainline` |
 | `place_basis_odds` | upstream raw, market-derived | `OZ.place_basis_odds` | pre-race | allow | allow via provenance | allow | low | parse failure -> `NULL` | live proxy では `place_basis_odds_proxy` alias を使う |
 | `headcount` | upstream raw, market-derived support field | `OZ.headcount` | pre-race | allow | allow via provenance | allow | low | parse failure -> `NULL` | provisional semantics。place market array header 由来 |
 | `distance_m` | upstream raw | `BAC.distance_m` | pre-race | allow | allow via provenance | allow | low | upstream null -> `NULL` | model parity では numeric feature としてのみ使用可 |
@@ -206,7 +207,6 @@ post-race or result-only:
 ### Fully Parity-Safe In Current Numeric Model Path
 
 - `win_odds`
-- `popularity`
 - `place_basis_odds`
 - `headcount`
 - `distance_m`
@@ -224,6 +224,16 @@ post-race or result-only:
 - dataset build で列化されている
 - `validate_model_feature_spec(...)` が train/rolling_retrain 入力として受理する
 - backtest rolling retrain でも同じ列順契約を持てる
+
+### Technically Supported But Non-Mainline
+
+- `popularity`
+
+意味:
+
+- 実装上は dataset / train / rolling_retrain / provenance で引き続き扱える
+- ただし carrier decision は `unresolved_keep_legacy_for_non-mainline_only`
+- mainline confirmed feature としては扱わない
 
 ### Dataset-Only Or Non-Parity-Safe In Current Path
 

--- a/docs/staging_contract.md
+++ b/docs/staging_contract.md
@@ -2,7 +2,7 @@
 
 この文書は、`raw -> staging` の取り込み結果を downstream がどう扱ってよいかを定義するための contract です。
 
-対象は現時点で `BAC`、`CHA`、`SED` です。ここでいう contract は、dataset builder が安全に参照してよい列、粒度、主キー候補、列の安定度を明文化したものです。
+対象は現時点で `BAC`、`CHA`、`SED` と project-owned pre-race win market contract です。ここでいう contract は、dataset builder が安全に参照してよい列、粒度、主キー候補、列の安定度を明文化したものです。
 
 ## Status Definitions
 
@@ -31,6 +31,16 @@ domain/group は upstream enum ではなく project-owned derived mapping とし
 - grain: 1 row per `race_key + horse_number`
 - primary key candidate: `race_key`, `horse_number`
 
+### `jrdb_pre_race_market_staging`
+
+- grain: 1 row per `race_key + horse_number`
+- primary key candidate: `race_key`, `horse_number`
+
+### `jrdb_win_market_snapshot_v1`
+
+- grain: 1 row per `race_key + horse_number`
+- primary key candidate: `race_key`, `horse_number`
+
 ## Dataset Builder Allowlist
 
 dataset builder が参照してよい列は以下に限定します。
@@ -54,11 +64,21 @@ dataset builder が参照してよい列は以下に限定します。
 
 ### SED allowlist
 
-- `win_odds`
 - `popularity`
 
-`SED` は主に target 生成用 staging として扱いますが、`odds_only` feature set では
-`win_odds` を必須、`popularity` を optional feature として参照できます。
+`SED` は主に target 生成用 staging として扱います。`popularity` は pre-race carrier 未確認のため、
+legacy / non-mainline path からだけ optional feature として参照します。
+
+### Pre-race win market contract
+
+- physical staging:
+  - `jrdb_pre_race_market_staging`
+- stable view:
+  - `jrdb_win_market_snapshot_v1`
+- current carrier mapping:
+  - `win_odds <- OZ.win_basis_odds -> jrdb_pre_race_market_staging -> jrdb_win_market_snapshot_v1`
+- current non-goal:
+  - `popularity` を同じ contract に載せない
 
 ## Data Dictionary
 
@@ -101,8 +121,24 @@ dataset builder が参照してよい列は以下に限定します。
 | `horse_name` | confirmed | deny | horse name in result file |
 | `distance_m` | provisional | deny | redundant with BAC distance |
 | `finish_position` | confirmed | deny | target generation source column |
-| `win_odds` | provisional | allow | allowed only for `odds_only` feature set |
-| `popularity` | provisional | allow | optional and allowed only for `odds_only` feature set |
+| `win_odds` | provisional | deny | legacy result-side value retained for traceability only; dataset builder uses `jrdb_win_market_snapshot_v1.win_odds` |
+| `popularity` | provisional | allow | optional and allowed only on the `legacy_sed_only_non_mainline` path |
+
+### `jrdb_pre_race_market_staging`
+
+| column | status | dataset use | notes |
+| --- | --- | --- | --- |
+| `race_key` | confirmed | allow | market snapshot join key |
+| `horse_number` | confirmed | allow | market snapshot join key |
+| `win_odds` | provisional | allow | current pre-race carrier value derived from `OZ.win_basis_odds` |
+
+### `jrdb_win_market_snapshot_v1`
+
+| column | status | dataset use | notes |
+| --- | --- | --- | --- |
+| `race_key` | confirmed | allow | stable contract key |
+| `horse_number` | confirmed | allow | stable contract key |
+| `win_odds` | provisional | allow | stable downstream carrier for win market odds |
 
 ## Confirmed vs Provisional
 
@@ -133,6 +169,7 @@ opaque:
 - dataset builder は allowlist 外の列を参照しない
 - `opaque` 列は traceability 専用であり、特徴量化や join key に使わない
 - `provisional` 列を dataset builder で使う場合も、この contract の allowlist に含まれる列のみに限定する
-- `SED` の `win_odds` / `popularity` は `odds_only` feature set からだけ参照する
+- `win_odds` は `jrdb_win_market_snapshot_v1` から参照する
+- `popularity` は pre-race carrier 未確認のため、`SED` legacy / non-mainline path からだけ参照する
 - `SED` の `finish_position` は target 生成専用であり feature に流さない
 - parser を更新しても、allowlist と grain を壊す変更は別 Issue で明示的に扱う

--- a/src/horse_bet_lab/features/registry.py
+++ b/src/horse_bet_lab/features/registry.py
@@ -93,7 +93,7 @@ FEATURE_REGISTRY: dict[str, FeatureDefinition] = {
         numeric_or_not=True,
         source_class="upstream_raw_market",
         timing_class="pre_race_semantic_post_race_carrier",
-        carrier_identity="legacy_sed_only",
+        carrier_identity="legacy_sed_only_non_mainline",
         leakage_allowed=True,
     ),
     "place_basis_odds": FeatureDefinition(

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -227,9 +227,9 @@ def test_build_horse_dataset_uses_win_market_snapshot_for_win_odds_and_legacy_se
     )
     definitions = {row["canonical_name"]: row for row in payload["feature_definitions"]}
     assert definitions["win_odds"]["carrier_identity"] == "win_market_snapshot_v1"
-    assert definitions["popularity"]["carrier_identity"] == "legacy_sed_only"
+    assert definitions["popularity"]["carrier_identity"] == "legacy_sed_only_non_mainline"
     assert payload["feature_source_summary"]["by_carrier_identity"] == {
-        "legacy_sed_only": 1,
+        "legacy_sed_only_non_mainline": 1,
         "win_market_snapshot_v1": 1,
     }
 


### PR DESCRIPTION
## Summary
- clarify that `popularity` is not a confirmed mainline carrier-backed feature
- classify `popularity` as `unresolved_keep_legacy_for_non-mainline_only`
- keep `popularity` on a legacy/non-mainline path rather than treating it as a confirmed pre-race mainline feature
- keep the current mainline runtime path centered on `win_odds`
- keep current hard-adopt baseline, BET logic, and frozen carrier decisions unchanged

## Scope
- minimal files only, limited to registry/spec/staging-contract/test updates needed to make the carrier decision explicit

## What this changes
- `popularity` is explicitly treated as non-mainline / legacy-backed rather than a confirmed carrier-backed mainline feature
- provenance/registry wording is aligned to the non-mainline legacy status
- docs/spec make the boundary explicit without broadening into unrelated runbook/README narrative

## What this does NOT change
- no BET logic changes
- no baseline rewrite
- no threshold / surcharge / guard changes
- no popularity carrier migration
- no frozen `win_odds` migration retry

## Validation
- `PYTHONPATH=src "/Users/matsurimbpblack/Library/Mobile Documents/com~apple~CloudDocs/codex_projects/horse-bet-lab/.venv/bin/pytest" tests/test_feature_registry.py`
- config load check confirming current mainline runtime feature columns remain `('win_odds',)`
- registry check confirming `FEATURE_REGISTRY["popularity"].carrier_identity == "legacy_sed_only_non_mainline"`

## Note
- `tests/test_dataset.py` is updated only to keep the provenance expectation aligned with the carrier naming change
- a direct standalone run of that test on current `origin/main` still hits an existing import drift in `tests/test_dataset.py` unrelated to this PR