### PR TITLE
implement OZ pre-race market adapter for place forward-test

### DIFF
--- a/docs/runbooks/jrdb_auto_ingestion_mvp.md
+++ b/docs/runbooks/jrdb_auto_ingestion_mvp.md
@@ -45,24 +45,24 @@ repo には入れない。
     }
   ],
   "handoff": {
-    "mode": "forward_pre_race_contract_like_csv_v1",
+    "mode": "forward_pre_race_oz_v1",
     "ingest_ready_files": true,
     "unit_id": "20260426_example_meeting",
-    "source_path": "/absolute/path/to/input_snapshot_contract_like.csv",
     "dataset_path": "/absolute/path/to/horse_dataset_odds_only_is_place.parquet",
     "duckdb_path": "/absolute/path/to/jrdb.duckdb",
     "model_version": "odds_only_logreg_is_place@20260426_example_meeting",
     "settled_as_of": "2026-04-26T18:00:00+09:00",
-    "input_source_name": "keibalab_public_pre_race_odds",
-    "input_source_url": "https://example.invalid/source",
+    "input_source_name": "jrdb_oz_official",
+    "input_source_url": "https://example.invalid/jrdb/oz",
     "input_source_timestamp": "2026-04-26T15:38:00+09:00",
     "odds_observation_timestamp": "2026-04-26T15:38:00+09:00",
-    "popularity_input_source": "keibalab_public_pre_race_odds"
+    "popularity_input_source": "jrdb_oz_official"
   }
 }
 ```
 
 `mode = "none"` にすると ready 化と result-side ingest だけ行う。
+`mode = "forward_pre_race_contract_like_csv_v1"` は従来どおり sanctioned local contract-like CSV を source にする開発/fixture path。
 
 ## CLI
 
@@ -134,5 +134,7 @@ optional Phase 1 artifacts:
 
 - production intent は email-triggered local run
 - ただし mailbox spec が未固定なので、MVP では manual / fixture trigger も正規の開発入口として持つ
-- current frozen boundary のため、official archive だけで pre-race input を自動構築する path は本 MVP では一般化しない
-- fixture smoke では `forward_pre_race_contract_like_csv_v1` を使って existing Phase 1 handoff を検証する
+- sanctioned mainline pre-race adapter は当面 `OZ*.txt` のみを読む
+- `popularity` は unresolved auxiliary のまま使わない
+- `SED` / `SRB` は current mainline pre-race adapter scope 外
+- fixture smoke では `forward_pre_race_oz_v1` または `forward_pre_race_contract_like_csv_v1` を使って existing Phase 1 handoff を検証できる

--- a/docs/spec/jrdb_auto_ingestion_mvp.md
+++ b/docs/spec/jrdb_auto_ingestion_mvp.md
@@ -215,6 +215,11 @@ current frozen boundaryに合わせ、MVP は pre-race handoff mode を明示的
   - official files の ready 化と result-side ingest だけ行う
 - `forward_pre_race_contract_like_csv_v1`
   - sanctioned local contract-like source CSV を既存 `raw_snapshot_prepare_cli` 相当で raw-ish input に変換し、Phase 1 pre-race まで起動する
+- `forward_pre_race_oz_v1`
+  - extracted official files から `OZ*.txt` を発見し、`race_key` / `horse_number` / `win_odds` / `place_basis_odds_proxy` を raw-ish input へ落として Phase 1 pre-race まで起動する
+  - sanctioned mainline pre-race adapter は当面 `OZ` のみを読む
+  - `popularity` は unresolved のまま扱い、raw-ish input に埋めない
+  - `SED` / `SRB` はこの adapter scope に含めない
 
 production intent は email-triggered local run だが、fixture smoke では `forward_pre_race_contract_like_csv_v1` を使う。
 
@@ -254,4 +259,3 @@ production intent は email-triggered local run だが、fixture smoke では `f
   - test 追加
 - secrets を repo に入れていない
   - env var / local auth config に限定
-

--- a/src/horse_bet_lab/jrdb_ingestion/handoff.py
+++ b/src/horse_bet_lab/jrdb_ingestion/handoff.py
@@ -16,8 +16,13 @@ from horse_bet_lab.forward_test.snapshot_bridge import (
     run_snapshot_bridge,
 )
 from horse_bet_lab.ingest.service import IngestionSummary, ingest_jrdb_directory
+from horse_bet_lab.jrdb_ingestion.oz_pre_race_adapter import (
+    discover_oz_source_paths,
+    run_oz_pre_race_adapter,
+)
 from horse_bet_lab.jrdb_ingestion.trigger import (
     HANDOFF_MODE_FORWARD_PRE_RACE_CONTRACT_LIKE,
+    HANDOFF_MODE_FORWARD_PRE_RACE_OZ,
     HANDOFF_MODE_NONE,
     JRDBAutoIngestionTrigger,
     JRDBForwardPreRaceHandoffConfig,
@@ -51,12 +56,21 @@ def run_handoff(
             pre_race_output_dir=None,
             unit_id=None,
         )
-    if trigger.handoff.mode != HANDOFF_MODE_FORWARD_PRE_RACE_CONTRACT_LIKE:
+    if trigger.handoff.mode not in {
+        HANDOFF_MODE_FORWARD_PRE_RACE_CONTRACT_LIKE,
+        HANDOFF_MODE_FORWARD_PRE_RACE_OZ,
+    }:
         raise ValueError(f"unsupported handoff mode: {trigger.handoff.mode!r}")
     if trigger.handoff.pre_race is None:
         raise ValueError("forward pre-race handoff requires pre_race config")
 
-    pre_race_output_dir = _run_forward_pre_race_contract_like_handoff(trigger.handoff.pre_race)
+    if trigger.handoff.mode == HANDOFF_MODE_FORWARD_PRE_RACE_CONTRACT_LIKE:
+        pre_race_output_dir = _run_forward_pre_race_contract_like_handoff(trigger.handoff.pre_race)
+    else:
+        pre_race_output_dir = _run_forward_pre_race_oz_handoff(
+            trigger.handoff.pre_race,
+            raw_target_dir=raw_target_dir,
+        )
     return JRDBHandoffResult(
         raw_target_dir=raw_target_dir,
         ingest_summary=ingest_summary,
@@ -68,6 +82,8 @@ def run_handoff(
 def _run_forward_pre_race_contract_like_handoff(
     config: JRDBForwardPreRaceHandoffConfig,
 ) -> Path:
+    if config.source_path is None:
+        raise ValueError("forward_pre_race_contract_like_csv_v1 requires source_path")
     scaffold_result = run_scaffold(
         PlaceForwardScaffoldConfig(
             unit_id=config.unit_id,
@@ -109,6 +125,60 @@ def _run_forward_pre_race_contract_like_handoff(
     run_raw_snapshot_prepare(
         preset_name=KNOWN_PRESET_PLACE_FORWARD_CONTRACT_LIKE,
         input_path=config.source_path,
+        output_path=scaffold_result.raw_dir / "input_snapshot_raw.csv",
+        force=True,
+    )
+    run_raw_snapshot_intake_precheck(bridge_config_path=scaffold_result.bridge_config_path)
+    run_snapshot_bridge(load_snapshot_bridge_config(scaffold_result.bridge_config_path))
+    run_place_forward_test(load_pre_race_config(scaffold_result.pre_race_config_path))
+    return scaffold_result.pre_race_output_dir
+
+
+def _run_forward_pre_race_oz_handoff(
+    config: JRDBForwardPreRaceHandoffConfig,
+    *,
+    raw_target_dir: Path,
+) -> Path:
+    scaffold_result = run_scaffold(
+        PlaceForwardScaffoldConfig(
+            unit_id=config.unit_id,
+            raw_input_path=Path(f"data/forward_test/runs/{config.unit_id}/raw/input_snapshot_raw.csv"),
+            contract_output_path=Path(
+                f"data/forward_test/runs/{config.unit_id}/contract/input_snapshot_{config.unit_id}.csv"
+            ),
+            pre_race_output_dir=Path(f"data/artifacts/place_forward_test/{config.unit_id}/pre_race"),
+            reconciliation_output_dir=Path(
+                f"data/artifacts/place_forward_test/{config.unit_id}/reconciliation"
+            ),
+            dataset_path=config.dataset_path,
+            duckdb_path=config.duckdb_path,
+            model_version=config.model_version,
+            candidate_logic_id="guard_0_01_plus_proxy_domain_overlay",
+            fallback_logic_id="no_bet_guard_stronger",
+            threshold=0.08,
+            settled_as_of=config.settled_as_of,
+            config_dir=Path("configs/recurring_rehearsal"),
+            bridge_config_path=Path(f"configs/recurring_rehearsal/{config.unit_id}.bridge.toml"),
+            pre_race_config_path=Path(
+                f"configs/recurring_rehearsal/{config.unit_id}.pre_race.toml"
+            ),
+            reconciliation_config_path=Path(
+                f"configs/recurring_rehearsal/{config.unit_id}.reconciliation.toml"
+            ),
+            notes_dir=Path(f"data/forward_test/runs/{config.unit_id}/notes"),
+            input_source_name=config.input_source_name,
+            input_source_url=config.input_source_url,
+            input_source_timestamp=config.input_source_timestamp,
+            odds_observation_timestamp=config.odds_observation_timestamp,
+            carrier_identity="place_forward_live_snapshot_v1",
+            retry_count=1,
+            timeout_seconds=15.0,
+            popularity_input_source=config.popularity_input_source,
+            force=True,
+        )
+    )
+    run_oz_pre_race_adapter(
+        source_paths=discover_oz_source_paths(raw_target_dir),
         output_path=scaffold_result.raw_dir / "input_snapshot_raw.csv",
         force=True,
     )

--- a/src/horse_bet_lab/jrdb_ingestion/oz_pre_race_adapter.py
+++ b/src/horse_bet_lab/jrdb_ingestion/oz_pre_race_adapter.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import csv
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from horse_bet_lab.ingest.transforms import decode_text
+
+RAW_ISH_OZ_OUTPUT_COLUMNS = (
+    "race_key",
+    "horse_number",
+    "win_odds",
+    "place_basis_odds_proxy",
+)
+
+
+@dataclass(frozen=True)
+class OZPreRaceMarketRow:
+    race_key: str
+    horse_number: int
+    headcount: int
+    win_odds: float
+    place_basis_odds: float
+
+
+@dataclass(frozen=True)
+class OZPreRaceAdapterResult:
+    source_paths: tuple[Path, ...]
+    output_path: Path
+    row_count: int
+    race_count: int
+
+
+def discover_oz_source_paths(raw_root: Path) -> tuple[Path, ...]:
+    if not raw_root.exists():
+        raise FileNotFoundError(f"OZ pre-race adapter raw root does not exist: {raw_root}")
+    source_paths = tuple(sorted(path for path in raw_root.rglob("OZ*.txt") if path.is_file()))
+    if not source_paths:
+        raise FileNotFoundError(f"OZ pre-race adapter found no OZ*.txt files under: {raw_root}")
+    return source_paths
+
+
+def parse_oz_line(
+    raw_line: bytes,
+    *,
+    source_path: Path,
+    line_number: int,
+) -> tuple[OZPreRaceMarketRow, ...]:
+    if not raw_line.strip():
+        return ()
+    text = decode_text(raw_line)
+    race_key = text[0:8].strip()
+    if race_key == "":
+        raise ValueError(f"{source_path} line {line_number}: missing race_key in chars 0:8")
+    headcount_text = text[8:10].strip()
+    if headcount_text == "":
+        raise ValueError(f"{source_path} line {line_number}: missing headcount in chars 8:10")
+    try:
+        headcount = int(headcount_text)
+    except ValueError as exc:
+        raise ValueError(
+            f"{source_path} line {line_number}: invalid OZ headcount {headcount_text!r}"
+        ) from exc
+    if headcount <= 0:
+        raise ValueError(
+            f"{source_path} line {line_number}: headcount must be positive, got {headcount}"
+        )
+
+    odds_values = re.findall(r"\d+\.\d", text[10:])
+    expected_count = headcount * 2
+    if len(odds_values) < expected_count:
+        raise ValueError(
+            (
+                f"{source_path} line {line_number}: expected at least {expected_count} "
+                f"OZ odds values, got {len(odds_values)}"
+            ),
+        )
+
+    win_odds = odds_values[:headcount]
+    place_basis_odds = odds_values[headcount:expected_count]
+    return tuple(
+        OZPreRaceMarketRow(
+            race_key=race_key,
+            horse_number=horse_number,
+            headcount=headcount,
+            win_odds=float(win_odds[horse_number - 1]),
+            place_basis_odds=float(place_basis_odds[horse_number - 1]),
+        )
+        for horse_number in range(1, headcount + 1)
+    )
+
+
+def read_oz_source_rows(source_paths: Iterable[Path]) -> tuple[OZPreRaceMarketRow, ...]:
+    rows: list[OZPreRaceMarketRow] = []
+    seen_keys: set[tuple[str, int]] = set()
+    for source_path in source_paths:
+        if not source_path.exists():
+            raise FileNotFoundError(
+                f"OZ pre-race adapter source file does not exist: {source_path}"
+            )
+        for line_number, raw_line in enumerate(source_path.read_bytes().splitlines(), start=1):
+            for row in parse_oz_line(raw_line, source_path=source_path, line_number=line_number):
+                key = (row.race_key, row.horse_number)
+                if key in seen_keys:
+                    raise ValueError(
+                        "OZ pre-race adapter found duplicate race_key/horse_number rows: "
+                        f"{key} from {source_path}"
+                    )
+                seen_keys.add(key)
+                rows.append(row)
+    if not rows:
+        raise ValueError("OZ pre-race adapter produced no rows from the provided source files")
+    return tuple(rows)
+
+
+def run_oz_pre_race_adapter(
+    *,
+    source_paths: Iterable[Path],
+    output_path: Path,
+    force: bool,
+) -> OZPreRaceAdapterResult:
+    source_paths = tuple(source_paths)
+    if not source_paths:
+        raise ValueError("OZ pre-race adapter requires at least one source path")
+    if output_path.exists() and not force:
+        raise FileExistsError(
+            "OZ pre-race adapter refuses to overwrite existing output without --force: "
+            f"{output_path}"
+        )
+
+    rows = read_oz_source_rows(source_paths)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8", newline="") as file:
+        writer = csv.DictWriter(file, fieldnames=list(RAW_ISH_OZ_OUTPUT_COLUMNS))
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(
+                {
+                    "race_key": row.race_key,
+                    "horse_number": str(row.horse_number),
+                    "win_odds": f"{row.win_odds:.1f}",
+                    "place_basis_odds_proxy": f"{row.place_basis_odds:.1f}",
+                }
+            )
+
+    return OZPreRaceAdapterResult(
+        source_paths=source_paths,
+        output_path=output_path,
+        row_count=len(rows),
+        race_count=len({row.race_key for row in rows}),
+    )

--- a/src/horse_bet_lab/jrdb_ingestion/trigger.py
+++ b/src/horse_bet_lab/jrdb_ingestion/trigger.py
@@ -7,10 +7,12 @@ from typing import Protocol
 
 HANDOFF_MODE_NONE = "none"
 HANDOFF_MODE_FORWARD_PRE_RACE_CONTRACT_LIKE = "forward_pre_race_contract_like_csv_v1"
+HANDOFF_MODE_FORWARD_PRE_RACE_OZ = "forward_pre_race_oz_v1"
 SUPPORTED_HANDOFF_MODES = frozenset(
     {
         HANDOFF_MODE_NONE,
         HANDOFF_MODE_FORWARD_PRE_RACE_CONTRACT_LIKE,
+        HANDOFF_MODE_FORWARD_PRE_RACE_OZ,
     }
 )
 
@@ -26,7 +28,7 @@ class JRDBArchiveTrigger:
 @dataclass(frozen=True)
 class JRDBForwardPreRaceHandoffConfig:
     unit_id: str
-    source_path: Path
+    source_path: Path | None
     dataset_path: Path
     duckdb_path: Path
     model_version: str
@@ -92,13 +94,17 @@ def load_trigger_manifest(path: Path) -> JRDBAutoIngestionTrigger:
 
     pre_race_payload = (
         handoff_payload
-        if mode == HANDOFF_MODE_FORWARD_PRE_RACE_CONTRACT_LIKE
+        if mode in {HANDOFF_MODE_FORWARD_PRE_RACE_CONTRACT_LIKE, HANDOFF_MODE_FORWARD_PRE_RACE_OZ}
         else None
     )
     pre_race = (
         JRDBForwardPreRaceHandoffConfig(
             unit_id=str(pre_race_payload["unit_id"]),
-            source_path=Path(str(pre_race_payload["source_path"])),
+            source_path=(
+                Path(str(pre_race_payload["source_path"]))
+                if pre_race_payload.get("source_path") is not None
+                else None
+            ),
             dataset_path=Path(str(pre_race_payload["dataset_path"])),
             duckdb_path=Path(str(pre_race_payload["duckdb_path"])),
             model_version=str(pre_race_payload["model_version"]),

--- a/tests/test_jrdb_auto_ingestion.py
+++ b/tests/test_jrdb_auto_ingestion.py
@@ -184,6 +184,97 @@ def test_jrdb_auto_ingestion_fixture_can_handoff_to_forward_pre_race(
     assert contract_csv_path.exists()
 
 
+def test_jrdb_auto_ingestion_fixture_can_handoff_from_oz_archive_to_forward_pre_race(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    archive_path = tmp_path / "fixture_oz.zip"
+    _write_zip(
+        archive_path,
+        {
+            "nested/OZ250105.txt": (
+                _make_oz_line(
+                    race_key="06251101",
+                    headcount=3,
+                    win_basis_odds=(2.4, 8.7, 15.2),
+                    place_basis_odds=(1.3, 2.8, 4.1),
+                )
+                + b"\r\n"
+            ),
+        },
+    )
+    dataset_path = tmp_path / "dataset.parquet"
+    duckdb_path = tmp_path / "jrdb.duckdb"
+    _write_dataset_parquet(dataset_path)
+    trigger_manifest_path = tmp_path / "trigger_oz.json"
+    trigger_manifest_path.write_text(
+        json.dumps(
+            {
+                "trigger_kind": "manual_fixture",
+                "message_id": "fixture-pre-race-oz",
+                "detected_at": "2026-04-21T11:00:00+09:00",
+                "archives": [
+                    {
+                        "name": "fixture_oz.zip",
+                        "source_uri": str(archive_path),
+                        "expected_sha256": _sha256_digest(archive_path),
+                        "archive_kind": "zip",
+                    }
+                ],
+                "handoff": {
+                    "mode": "forward_pre_race_oz_v1",
+                    "ingest_ready_files": False,
+                    "unit_id": "20260426_oz_meeting",
+                    "dataset_path": str(dataset_path),
+                    "duckdb_path": str(duckdb_path),
+                    "model_version": "odds_only_logreg_is_place@fixture",
+                    "settled_as_of": "2026-04-26T18:00:00+09:00",
+                    "input_source_name": "jrdb_oz_official",
+                    "input_source_url": "https://example.invalid/jrdb/oz",
+                    "input_source_timestamp": "2026-04-26T15:38:00+09:00",
+                    "odds_observation_timestamp": "2026-04-26T15:38:00+09:00",
+                    "popularity_input_source": "jrdb_oz_official",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    trigger = load_trigger_manifest(trigger_manifest_path)
+    result = run_jrdb_auto_ingestion_job(
+        trigger,
+        workspace_root=tmp_path / "workspace",
+        raw_dir=tmp_path / "raw",
+    )
+
+    assert result.status == "completed"
+    run_manifest_path = (
+        tmp_path
+        / "data"
+        / "artifacts"
+        / "place_forward_test"
+        / "20260426_oz_meeting"
+        / "pre_race"
+        / "run_manifest.json"
+    )
+    assert run_manifest_path.exists()
+    run_manifest = json.loads(run_manifest_path.read_text(encoding="utf-8"))
+    assert run_manifest["record_counts"]["decision_records"] == 3
+    raw_snapshot_path = (
+        tmp_path
+        / "data"
+        / "forward_test"
+        / "runs"
+        / "20260426_oz_meeting"
+        / "raw"
+        / "input_snapshot_raw.csv"
+    )
+    rows = list(csv.DictReader(raw_snapshot_path.open(encoding="utf-8")))
+    assert len(rows) == 3
+    assert rows[0]["place_basis_odds_proxy"] == "1.3"
+
+
 def _write_zip(path: Path, files: dict[str, bytes]) -> None:
     with zipfile.ZipFile(path, "w") as archive:
         for name, content in files.items():
@@ -280,3 +371,15 @@ def _sha256_digest(path: Path) -> str:
     digest = hashlib.sha256()
     digest.update(path.read_bytes())
     return digest.hexdigest()
+
+
+def _make_oz_line(
+    *,
+    race_key: str,
+    headcount: int,
+    win_basis_odds: tuple[float, ...],
+    place_basis_odds: tuple[float, ...],
+) -> bytes:
+    win_text = "".join(f"{value:>5.1f}" for value in win_basis_odds)
+    place_text = "".join(f"{value:>5.1f}" for value in place_basis_odds)
+    return f"{race_key[:8].ljust(8)}{headcount:02d}{win_text}{' ' * 12}{place_text}".encode("ascii")

--- a/tests/test_jrdb_oz_pre_race_adapter.py
+++ b/tests/test_jrdb_oz_pre_race_adapter.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from horse_bet_lab.forward_test.raw_snapshot_intake import run_raw_snapshot_intake_precheck
+from horse_bet_lab.forward_test.scaffold import PlaceForwardScaffoldConfig, run_scaffold
+from horse_bet_lab.jrdb_ingestion.oz_pre_race_adapter import (
+    parse_oz_line,
+    run_oz_pre_race_adapter,
+)
+
+
+def test_parse_oz_line_expands_headcount_rows() -> None:
+    rows = parse_oz_line(
+        make_oz_line(
+            race_key="06251101",
+            headcount=3,
+            win_basis_odds=(2.4, 8.7, 15.2),
+            place_basis_odds=(1.3, 2.8, 4.1),
+        ),
+        source_path=Path("OZ250105.txt"),
+        line_number=1,
+    )
+
+    assert [row.horse_number for row in rows] == [1, 2, 3]
+    assert [row.win_odds for row in rows] == [2.4, 8.7, 15.2]
+    assert [row.place_basis_odds for row in rows] == [1.3, 2.8, 4.1]
+
+
+def test_oz_pre_race_adapter_writes_bridge_ready_raw_csv_and_passes_intake(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    oz_path = tmp_path / "raw" / "nested" / "OZ250105.txt"
+    oz_path.parent.mkdir(parents=True, exist_ok=True)
+    oz_path.write_bytes(
+        make_oz_line(
+            race_key="06251101",
+            headcount=3,
+            win_basis_odds=(2.4, 8.7, 15.2),
+            place_basis_odds=(1.3, 2.8, 4.1),
+        )
+        + b"\r\n"
+    )
+
+    scaffold_result = run_scaffold(
+        PlaceForwardScaffoldConfig(
+            unit_id="20260426_oz_fixture",
+            raw_input_path=Path("data/forward_test/runs/20260426_oz_fixture/raw/input_snapshot_raw.csv"),
+            contract_output_path=Path(
+                "data/forward_test/runs/20260426_oz_fixture/contract/input_snapshot_20260426_oz_fixture.csv"
+            ),
+            pre_race_output_dir=Path("data/artifacts/place_forward_test/20260426_oz_fixture/pre_race"),
+            reconciliation_output_dir=Path(
+                "data/artifacts/place_forward_test/20260426_oz_fixture/reconciliation"
+            ),
+            dataset_path=tmp_path / "dataset.parquet",
+            duckdb_path=tmp_path / "jrdb.duckdb",
+            model_version="odds_only_logreg_is_place@fixture",
+            candidate_logic_id="guard_0_01_plus_proxy_domain_overlay",
+            fallback_logic_id="no_bet_guard_stronger",
+            threshold=0.08,
+            settled_as_of="2026-04-26T18:00:00+09:00",
+            config_dir=Path("configs/recurring_rehearsal"),
+            bridge_config_path=Path("configs/recurring_rehearsal/20260426_oz_fixture.bridge.toml"),
+            pre_race_config_path=Path("configs/recurring_rehearsal/20260426_oz_fixture.pre_race.toml"),
+            reconciliation_config_path=Path(
+                "configs/recurring_rehearsal/20260426_oz_fixture.reconciliation.toml"
+            ),
+            notes_dir=Path("data/forward_test/runs/20260426_oz_fixture/notes"),
+            input_source_name="jrdb_oz_official",
+            input_source_url="https://example.invalid/jrdb/oz",
+            input_source_timestamp="2026-04-26T15:38:00+09:00",
+            odds_observation_timestamp="2026-04-26T15:38:00+09:00",
+            carrier_identity="place_forward_live_snapshot_v1",
+            retry_count=1,
+            timeout_seconds=15.0,
+            popularity_input_source="jrdb_oz_official",
+            force=True,
+        )
+    )
+
+    result = run_oz_pre_race_adapter(
+        source_paths=(oz_path,),
+        output_path=scaffold_result.raw_dir / "input_snapshot_raw.csv",
+        force=True,
+    )
+
+    assert result.row_count == 3
+    rows = list(
+        csv.DictReader(
+            (scaffold_result.raw_dir / "input_snapshot_raw.csv").open(encoding="utf-8")
+        )
+    )
+    assert rows[0] == {
+        "race_key": "06251101",
+        "horse_number": "1",
+        "win_odds": "2.4",
+        "place_basis_odds_proxy": "1.3",
+    }
+    precheck = run_raw_snapshot_intake_precheck(
+        bridge_config_path=scaffold_result.bridge_config_path
+    )
+    assert precheck.unit_id == "20260426_oz_fixture"
+
+
+def make_oz_line(
+    *,
+    race_key: str,
+    headcount: int,
+    win_basis_odds: tuple[float, ...],
+    place_basis_odds: tuple[float, ...],
+) -> bytes:
+    win_text = "".join(f"{value:>5.1f}" for value in win_basis_odds)
+    place_text = "".join(f"{value:>5.1f}" for value in place_basis_odds)
+    return f"{race_key[:8].ljust(8)}{headcount:02d}{win_text}{' ' * 12}{place_text}".encode("ascii")


### PR DESCRIPTION
## Summary
- add an OZ-only sanctioned pre-race market adapter for the current place-only forward-test path
- parse `OZ*.txt` rows, expand by `headcount`, and produce bridge-ready raw-ish CSV
- add `forward_pre_race_oz_v1` as a new JRDB ingestion handoff mode
- connect official extracted `OZ*.txt` to the existing intake precheck / bridge / pre-race runner flow
- keep `popularity` unresolved and out of the mainline adapter scope
- keep current hard-adopt baseline, BET logic, and frozen carrier decisions unchanged

## Included commit
- `7ecfc3e` — `implement OZ pre-race market adapter for place forward-test`

## Scope
- `src/horse_bet_lab/jrdb_ingestion/oz_pre_race_adapter.py`
- `src/horse_bet_lab/jrdb_ingestion/handoff.py`
- `src/horse_bet_lab/jrdb_ingestion/trigger.py`
- `tests/test_jrdb_oz_pre_race_adapter.py`
- `tests/test_jrdb_auto_ingestion.py`
- `docs/spec/jrdb_auto_ingestion_mvp.md`
- `docs/runbooks/jrdb_auto_ingestion_mvp.md`

## What this adds
### OZ adapter
- reads `OZ*.txt`
- extracts:
  - `race_key`
  - `horse_number`
  - `win_odds`
  - `place_basis_odds_proxy`
- expands horse rows using `headcount`
- writes bridge-ready raw-ish CSV for the existing Phase 1 flow

### New handoff mode
- `forward_pre_race_oz_v1`
- official archive -> extracted `OZ*.txt` -> raw-ish input -> intake precheck -> bridge -> pre-race

## What this does NOT change
- no BET logic changes
- no baseline rewrite
- no threshold / surcharge / guard changes
- no popularity carrier resolution
- no frozen `win_odds` migration retry
- no `SED` / `SRB` mainline pre-race adapter
- no proprietary data committed

## Validation
- `pytest tests/test_jrdb_oz_pre_race_adapter.py tests/test_jrdb_auto_ingestion.py tests/test_place_forward_snapshot_bridge.py tests/test_place_forward_raw_snapshot_prepare.py`
- `ruff check src/horse_bet_lab/jrdb_ingestion tests/test_jrdb_auto_ingestion.py tests/test_jrdb_oz_pre_race_adapter.py`
- real local official archive smoke:
  - `PACI260412.zip`
  - found `OZ260412.txt`
  - `forward_pre_race_oz_v1` succeeded through pre-race
  - `bet=2`, `no_bet=520`