### PR TITLE
Phase652: audit historical signal robustness

### DIFF
--- a/docs/phase652_historical_signal_robustness.md
+++ b/docs/phase652_historical_signal_robustness.md
@@ -1,0 +1,76 @@
+# Phase652 Historical Signal Robustness
+
+## Purpose
+
+Phase651 found a small incremental signal from strictly-prior horse history. Phase652 tests
+whether that read survives a stricter stacking contract and identifies where it is fragile.
+
+This phase does not select a model from 2025 results and does not connect the signal to betting or
+expected value.
+
+## Frozen inputs
+
+- market logistic `C=3.0`;
+- offset residual `C=1.0`;
+- Phase650H history feature surface;
+- Phase651 place-slot-aware target;
+- 2023 training and 2024 validation;
+- 2023-2024 refit and 2025 reused confirmation.
+
+The 2025 period is not called a new holdout because its result was already inspected in Phase651.
+
+## Cross-fit contract
+
+Training offsets are produced by five-fold `StratifiedGroupKFold`, grouped by `race_key`.
+No training row receives a market probability from a model trained on its own label. The final
+evaluation market model still fits all rows available before the evaluation period.
+
+## Feature groups
+
+- current context: venue, distance, card field size;
+- history depth and recency: prior starts, days since last start;
+- recent form: finish percentiles, top-three rates, recency-weighted form;
+- compatibility: recent distance and venue compatibility rates.
+
+Each leave-one-group-out result is diagnostic only. Hyperparameters remain frozen.
+
+Two targeted controls are evaluated with the same paired race bootstrap as the full model:
+
+- history-only residual: removes venue, current distance, and card field size;
+- current-context-only residual: removes every strictly-prior history group.
+
+The historical-residual hypothesis is confirmed only if the history-only residual improves both
+matched market baselines in both periods. This prevents current race context from being mislabeled
+as horse-history signal.
+
+## Stability slices
+
+The full cross-fitted model is compared with its matched market baseline by:
+
+- prior-start depth;
+- active field size;
+- market popularity;
+- half-year.
+
+Race-level paired bootstrap intervals are emitted for every sufficiently large subgroup.
+An overall improvement does not imply uniform improvement. Statistically supported harmful
+subgroups are emitted in the summary and keep the result research-only even when the overall
+bootstrap verdict is positive.
+
+## Adoption boundary
+
+This phase may confirm that prior-history features contain incremental probability signal. It
+cannot authorize a betting rule. A positive overall verdict is retained as a diagnostic when a
+known subgroup fails, when payout/EV has not been evaluated, or while 2025 remains a reused
+confirmation period rather than a fresh holdout.
+
+## Execution
+
+```bash
+PYTHONPATH=src .venv/bin/python scripts/phase652_historical_signal_robustness.py \
+  --history-surface /absolute/path/phase650h_history_surface.csv \
+  --source-summary /absolute/path/phase650h_source_summary.json \
+  --market-dataset /absolute/path/dual_market_logreg/dataset.parquet
+```
+
+Generated reports remain under `data/artifacts/` and are not committed.

--- a/scripts/phase652_historical_signal_robustness.py
+++ b/scripts/phase652_historical_signal_robustness.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from horse_bet_lab.research.historical_ability_models import load_comparison_dataset
+from horse_bet_lab.research.historical_signal_robustness import (
+    run_signal_robustness,
+    write_robustness_result,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Cross-fit and diagnose the Phase651 historical residual signal.",
+    )
+    parser.add_argument("--history-surface", type=Path, required=True)
+    parser.add_argument("--source-summary", type=Path, required=True)
+    parser.add_argument("--market-dataset", type=Path, required=True)
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("data/artifacts/phase652_historical_signal_robustness"),
+    )
+    parser.add_argument("--bootstrap-repetitions", type=int, default=2_000)
+    parser.add_argument("--subgroup-bootstrap-repetitions", type=int, default=500)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    dataset, _ = load_comparison_dataset(
+        history_surface_path=args.history_surface,
+        source_summary_path=args.source_summary,
+        market_dataset_path=args.market_dataset,
+    )
+    result = run_signal_robustness(
+        dataset,
+        bootstrap_repetitions=args.bootstrap_repetitions,
+        subgroup_bootstrap_repetitions=args.subgroup_bootstrap_repetitions,
+    )
+    write_robustness_result(result, args.output_dir)
+    print(json.dumps(result.summary, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/horse_bet_lab/research/historical_ability_models.py
+++ b/src/horse_bet_lab/research/historical_ability_models.py
@@ -888,6 +888,33 @@ def _fit_offset_logistic(
     )
 
 
+def fit_logistic_probability_model(
+    values: FloatArray,
+    targets: IntArray,
+    c_value: float,
+) -> LogisticRegression:
+    """Fit the frozen Phase651 logistic family for research extensions."""
+    return _fit_logistic(values, targets, c_value)
+
+
+def predict_positive_probability(
+    model: LogisticRegression,
+    values: FloatArray,
+) -> FloatArray:
+    """Return positive-class probabilities from a Phase651 logistic model."""
+    return _positive_probability(model, values)
+
+
+def fit_offset_probability_model(
+    values: FloatArray,
+    targets: IntArray,
+    offset_probabilities: FloatArray,
+    c_value: float,
+) -> OffsetLogisticModel:
+    """Fit the fixed-market-logit residual family used by Phase651."""
+    return _fit_offset_logistic(values, targets, offset_probabilities, c_value)
+
+
 def _hyperparameter_row(
     model_name: str,
     c_value: float,

--- a/src/horse_bet_lab/research/historical_signal_robustness.py
+++ b/src/horse_bet_lab/research/historical_signal_robustness.py
@@ -1,0 +1,813 @@
+from __future__ import annotations
+
+import csv
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+import numpy as np
+from numpy.typing import NDArray
+from sklearn.metrics import log_loss  # type: ignore[import-untyped]
+from sklearn.model_selection import StratifiedGroupKFold  # type: ignore[import-untyped]
+
+from horse_bet_lab.research.historical_ability_models import (
+    HISTORY_NUMERIC_FEATURE_COLUMNS,
+    ComparisonDataset,
+    FloatArray,
+    HistoryTransformer,
+    IntArray,
+    NumericTransformer,
+    ObjectArray,
+    constrain_probabilities_by_race,
+    fit_logistic_probability_model,
+    fit_offset_probability_model,
+    metric_row,
+    predict_positive_probability,
+    race_bootstrap_log_loss_delta,
+)
+
+MARKET_C = 3.0
+OFFSET_C = 1.0
+CROSSFIT_FOLDS = 5
+
+ROBUSTNESS_CONFIRMED = "HISTORY_SIGNAL_CROSSFIT_ROBUSTNESS_CONFIRMED"
+ROBUSTNESS_DIAGNOSTIC_ONLY = "HISTORY_SIGNAL_CROSSFIT_DIAGNOSTIC_ONLY"
+ROBUSTNESS_NOT_CONFIRMED = "HISTORY_SIGNAL_CROSSFIT_NOT_CONFIRMED"
+RESEARCH_ONLY = "RETAIN_AS_PROBABILITY_DIAGNOSTIC_NOT_BETTING_RULE"
+
+FEATURE_GROUPS: dict[str, tuple[str, ...]] = {
+    "current_context": ("venue_code", "current_distance_m", "card_field_size"),
+    "history_depth_recency": ("prior_start_count", "days_since_last_start"),
+    "recent_form": (
+        "last_1_finish_percentile",
+        "last_3_mean_finish_percentile",
+        "last_5_mean_finish_percentile",
+        "last_3_top3_rate",
+        "last_5_top3_rate",
+        "last_5_recency_weighted_form",
+    ),
+    "compatibility": (
+        "last_5_distance_compatibility_rate",
+        "last_5_venue_compatibility_rate",
+    ),
+}
+
+
+@dataclass(frozen=True)
+class FeatureSubset:
+    name: str
+    numeric_indices: tuple[int, ...]
+    raw_feature_names: tuple[str, ...]
+    use_venue: bool
+
+
+@dataclass(frozen=True)
+class MarketContext:
+    train_oof_probabilities: FloatArray
+    train_in_sample_probabilities: FloatArray
+    evaluation_probabilities: FloatArray
+    constrained_evaluation_probabilities: FloatArray
+
+
+@dataclass(frozen=True)
+class VariantPredictions:
+    offset: FloatArray
+    constrained_offset: FloatArray
+    encoded_feature_count: int
+
+
+@dataclass(frozen=True)
+class RobustnessResult:
+    summary: dict[str, Any]
+    metrics: tuple[dict[str, Any], ...]
+    ablation_rows: tuple[dict[str, Any], ...]
+    bootstrap_rows: tuple[dict[str, Any], ...]
+    subgroup_rows: tuple[dict[str, Any], ...]
+
+
+def feature_subsets() -> tuple[FeatureSubset, ...]:
+    all_raw_features = ("venue_code", *HISTORY_NUMERIC_FEATURE_COLUMNS)
+    subsets = [
+        _feature_subset("full_crossfit", excluded=()),
+        _feature_subset("without_current_context", excluded=("current_context",)),
+        _feature_subset(
+            "current_context_only",
+            excluded=("history_depth_recency", "recent_form", "compatibility"),
+        ),
+        _feature_subset("without_history_depth_recency", excluded=("history_depth_recency",)),
+        _feature_subset("without_recent_form", excluded=("recent_form",)),
+        _feature_subset("without_compatibility", excluded=("compatibility",)),
+    ]
+    if set(FEATURE_GROUPS).difference(
+        {"current_context", "history_depth_recency", "recent_form", "compatibility"}
+    ):
+        raise AssertionError("unexpected feature group")
+    grouped_features = {
+        feature for group_features in FEATURE_GROUPS.values() for feature in group_features
+    }
+    if grouped_features != set(all_raw_features):
+        raise ValueError(
+            "feature groups must cover the Phase651 history contract exactly: "
+            f"missing={set(all_raw_features) - grouped_features}, "
+            f"extra={grouped_features - set(all_raw_features)}"
+        )
+    return tuple(subsets)
+
+
+def cross_fitted_market_probabilities(
+    dataset: ComparisonDataset,
+    *,
+    c_value: float = MARKET_C,
+    folds: int = CROSSFIT_FOLDS,
+    random_seed: int = 652,
+) -> FloatArray:
+    unique_races = len(set(str(value) for value in dataset.race_keys))
+    if unique_races < folds:
+        raise ValueError(f"cross-fit requires at least {folds} races, got {unique_races}")
+    splitter = StratifiedGroupKFold(
+        n_splits=folds,
+        shuffle=True,
+        random_state=random_seed,
+    )
+    predictions = np.full(len(dataset.targets), np.nan, dtype=np.float64)
+    for train_indices, validation_indices in splitter.split(
+        dataset.market_features,
+        dataset.targets,
+        groups=dataset.race_keys,
+    ):
+        transformer = NumericTransformer.fit(dataset.market_features[train_indices])
+        train_values = transformer.transform(dataset.market_features[train_indices])
+        validation_values = transformer.transform(dataset.market_features[validation_indices])
+        model = fit_logistic_probability_model(
+            train_values,
+            dataset.targets[train_indices],
+            c_value,
+        )
+        predictions[validation_indices] = predict_positive_probability(model, validation_values)
+    if np.isnan(predictions).any():
+        raise RuntimeError("cross-fit did not predict every training row")
+    return predictions
+
+
+def run_signal_robustness(
+    dataset: ComparisonDataset,
+    *,
+    market_c: float = MARKET_C,
+    offset_c: float = OFFSET_C,
+    crossfit_folds: int = CROSSFIT_FOLDS,
+    bootstrap_repetitions: int = 2_000,
+    subgroup_bootstrap_repetitions: int = 500,
+    minimum_subgroup_rows: int = 200,
+    random_seed: int = 652,
+) -> RobustnessResult:
+    years = dataset.years
+    train_2023 = dataset.subset(years == 2023)
+    validation_2024 = dataset.subset(years == 2024)
+    train_2023_2024 = dataset.subset(np.isin(years, [2023, 2024]))
+    confirmation_2025 = dataset.subset(years == 2025)
+    if (
+        min(
+            len(train_2023.targets),
+            len(validation_2024.targets),
+            len(confirmation_2025.targets),
+        )
+        == 0
+    ):
+        raise ValueError("2023, 2024, and 2025 rows are required")
+
+    periods = (
+        (
+            "2024_validation",
+            train_2023,
+            validation_2024,
+            _build_market_context(
+                train_2023,
+                validation_2024,
+                c_value=market_c,
+                folds=crossfit_folds,
+                random_seed=random_seed,
+            ),
+        ),
+        (
+            "2025_reused_confirmation",
+            train_2023_2024,
+            confirmation_2025,
+            _build_market_context(
+                train_2023_2024,
+                confirmation_2025,
+                c_value=market_c,
+                folds=crossfit_folds,
+                random_seed=random_seed,
+            ),
+        ),
+    )
+
+    metrics: list[dict[str, Any]] = []
+    ablation_rows: list[dict[str, Any]] = []
+    bootstrap_rows: list[dict[str, Any]] = []
+    subgroup_rows: list[dict[str, Any]] = []
+
+    full_predictions_by_period: dict[
+        str, tuple[ComparisonDataset, MarketContext, VariantPredictions]
+    ] = {}
+    for period_label, train, evaluation, market_context in periods:
+        metrics.extend(
+            (
+                metric_row(
+                    period_label,
+                    "M1_market",
+                    evaluation,
+                    market_context.evaluation_probabilities,
+                ),
+                metric_row(
+                    period_label,
+                    "M1C_race_constrained_market",
+                    evaluation,
+                    market_context.constrained_evaluation_probabilities,
+                ),
+            )
+        )
+        full_subset = _feature_subset("full_crossfit", excluded=())
+        full_crossfit = _fit_history_variant(
+            train,
+            evaluation,
+            market_context,
+            full_subset,
+            offset_c=offset_c,
+            use_cross_fitted_offset=True,
+        )
+        full_in_sample = _fit_history_variant(
+            train,
+            evaluation,
+            market_context,
+            full_subset,
+            offset_c=offset_c,
+            use_cross_fitted_offset=False,
+        )
+        full_predictions_by_period[period_label] = (evaluation, market_context, full_crossfit)
+        metrics.extend(
+            (
+                metric_row(
+                    period_label,
+                    "M4_crossfit_full",
+                    evaluation,
+                    full_crossfit.offset,
+                ),
+                metric_row(
+                    period_label,
+                    "M5_crossfit_full",
+                    evaluation,
+                    full_crossfit.constrained_offset,
+                ),
+                metric_row(
+                    period_label,
+                    "M4_in_sample_offset_reference",
+                    evaluation,
+                    full_in_sample.offset,
+                ),
+            )
+        )
+        bootstrap_rows.extend(
+            (
+                race_bootstrap_log_loss_delta(
+                    period_label=period_label,
+                    baseline_name="M1_market",
+                    candidate_name="M4_crossfit_full",
+                    targets=evaluation.targets,
+                    baseline_probabilities=market_context.evaluation_probabilities,
+                    candidate_probabilities=full_crossfit.offset,
+                    race_keys=evaluation.race_keys,
+                    repetitions=bootstrap_repetitions,
+                    random_seed=random_seed,
+                ),
+                race_bootstrap_log_loss_delta(
+                    period_label=period_label,
+                    baseline_name="M1C_race_constrained_market",
+                    candidate_name="M5_crossfit_full",
+                    targets=evaluation.targets,
+                    baseline_probabilities=market_context.constrained_evaluation_probabilities,
+                    candidate_probabilities=full_crossfit.constrained_offset,
+                    race_keys=evaluation.race_keys,
+                    repetitions=bootstrap_repetitions,
+                    random_seed=random_seed,
+                ),
+                race_bootstrap_log_loss_delta(
+                    period_label=period_label,
+                    baseline_name="M4_in_sample_offset_reference",
+                    candidate_name="M4_crossfit_full",
+                    targets=evaluation.targets,
+                    baseline_probabilities=full_in_sample.offset,
+                    candidate_probabilities=full_crossfit.offset,
+                    race_keys=evaluation.race_keys,
+                    repetitions=bootstrap_repetitions,
+                    random_seed=random_seed,
+                ),
+            )
+        )
+
+        full_offset_log_loss = _log_loss(evaluation.targets, full_crossfit.offset)
+        full_constrained_log_loss = _log_loss(
+            evaluation.targets,
+            full_crossfit.constrained_offset,
+        )
+        for subset in feature_subsets():
+            if subset.name == "full_crossfit":
+                predictions = full_crossfit
+            else:
+                predictions = _fit_history_variant(
+                    train,
+                    evaluation,
+                    market_context,
+                    subset,
+                    offset_c=offset_c,
+                    use_cross_fitted_offset=True,
+                )
+            offset_log_loss = _log_loss(evaluation.targets, predictions.offset)
+            constrained_log_loss = _log_loss(
+                evaluation.targets,
+                predictions.constrained_offset,
+            )
+            ablation_rows.extend(
+                (
+                    _ablation_row(
+                        period_label,
+                        subset,
+                        "offset",
+                        predictions.encoded_feature_count,
+                        offset_log_loss,
+                        full_offset_log_loss,
+                        _log_loss(
+                            evaluation.targets,
+                            market_context.evaluation_probabilities,
+                        ),
+                    ),
+                    _ablation_row(
+                        period_label,
+                        subset,
+                        "constrained_offset",
+                        predictions.encoded_feature_count,
+                        constrained_log_loss,
+                        full_constrained_log_loss,
+                        _log_loss(
+                            evaluation.targets,
+                            market_context.constrained_evaluation_probabilities,
+                        ),
+                    ),
+                )
+            )
+            if subset.name in {"without_current_context", "current_context_only"}:
+                signal_label = (
+                    "history_only" if subset.name == "without_current_context" else "context_only"
+                )
+                bootstrap_rows.extend(
+                    (
+                        race_bootstrap_log_loss_delta(
+                            period_label=period_label,
+                            baseline_name="M1_market",
+                            candidate_name=f"M4_crossfit_{signal_label}",
+                            targets=evaluation.targets,
+                            baseline_probabilities=market_context.evaluation_probabilities,
+                            candidate_probabilities=predictions.offset,
+                            race_keys=evaluation.race_keys,
+                            repetitions=bootstrap_repetitions,
+                            random_seed=random_seed,
+                        ),
+                        race_bootstrap_log_loss_delta(
+                            period_label=period_label,
+                            baseline_name="M1C_race_constrained_market",
+                            candidate_name=f"M5_crossfit_{signal_label}",
+                            targets=evaluation.targets,
+                            baseline_probabilities=(
+                                market_context.constrained_evaluation_probabilities
+                            ),
+                            candidate_probabilities=predictions.constrained_offset,
+                            race_keys=evaluation.race_keys,
+                            repetitions=bootstrap_repetitions,
+                            random_seed=random_seed,
+                        ),
+                    )
+                )
+
+    for period_label, (
+        evaluation,
+        market_context,
+        predictions,
+    ) in full_predictions_by_period.items():
+        for model_name, baseline_name, baseline, candidate in (
+            (
+                "M4_crossfit_full",
+                "M1_market",
+                market_context.evaluation_probabilities,
+                predictions.offset,
+            ),
+            (
+                "M5_crossfit_full",
+                "M1C_race_constrained_market",
+                market_context.constrained_evaluation_probabilities,
+                predictions.constrained_offset,
+            ),
+        ):
+            for dimension, subgroup, mask in _subgroup_masks(evaluation):
+                if (
+                    int(mask.sum()) < minimum_subgroup_rows
+                    or len(np.unique(evaluation.targets[mask])) < 2
+                ):
+                    continue
+                bootstrap = race_bootstrap_log_loss_delta(
+                    period_label=f"{period_label}:{dimension}:{subgroup}",
+                    baseline_name=baseline_name,
+                    candidate_name=model_name,
+                    targets=evaluation.targets[mask],
+                    baseline_probabilities=baseline[mask],
+                    candidate_probabilities=candidate[mask],
+                    race_keys=evaluation.race_keys[mask],
+                    repetitions=subgroup_bootstrap_repetitions,
+                    random_seed=random_seed,
+                )
+                subgroup_rows.append(
+                    {
+                        "period_label": period_label,
+                        "model_name": model_name,
+                        "baseline_name": baseline_name,
+                        "dimension": dimension,
+                        "subgroup": subgroup,
+                        "row_count": int(mask.sum()),
+                        "race_count": bootstrap["race_count"],
+                        "baseline_log_loss": _log_loss(evaluation.targets[mask], baseline[mask]),
+                        "candidate_log_loss": _log_loss(evaluation.targets[mask], candidate[mask]),
+                        "point_log_loss_delta": bootstrap["point_log_loss_delta"],
+                        "ci95_low": bootstrap["ci95_low"],
+                        "ci95_high": bootstrap["ci95_high"],
+                        "bootstrap_probability_improved": bootstrap[
+                            "bootstrap_probability_improved"
+                        ],
+                    }
+                )
+
+    final_verdict, evidence = _robustness_verdict(bootstrap_rows)
+    supported_failure_pockets = [row for row in subgroup_rows if float(row["ci95_low"]) > 0.0]
+    summary: dict[str, Any] = {
+        "analysis_version": "phase652_historical_signal_robustness_v1",
+        "final_verdict": final_verdict,
+        "phase651_hyperparameters_frozen": {
+            "market_c": market_c,
+            "offset_c": offset_c,
+        },
+        "crossfit_contract": {
+            "folds": crossfit_folds,
+            "group": "race_key",
+            "splitter": "StratifiedGroupKFold",
+            "training_offset_predictions_are_out_of_fold": True,
+        },
+        "period_contract": {
+            "2024": "validation under 2023 training",
+            "2025": "reused confirmation only; not a fresh holdout",
+        },
+        "feature_groups": FEATURE_GROUPS,
+        "feature_ablation_used_for_selection": False,
+        "roi_or_betting_used": False,
+        "operational_recommendation": RESEARCH_ONLY,
+        "uniform_subgroup_improvement_supported": bool(subgroup_rows)
+        and all(float(row["ci95_high"]) < 0.0 for row in subgroup_rows),
+        "supported_failure_pockets": supported_failure_pockets,
+        "bootstrap_repetitions": bootstrap_repetitions,
+        "subgroup_bootstrap_repetitions": subgroup_bootstrap_repetitions,
+        "minimum_subgroup_rows": minimum_subgroup_rows,
+        "verdict_evidence": evidence,
+        "historical_residual_hypothesis_requires": (
+            "history-only residual improvement against matched market baselines"
+        ),
+    }
+    return RobustnessResult(
+        summary=summary,
+        metrics=tuple(metrics),
+        ablation_rows=tuple(ablation_rows),
+        bootstrap_rows=tuple(bootstrap_rows),
+        subgroup_rows=tuple(subgroup_rows),
+    )
+
+
+def write_robustness_result(result: RobustnessResult, output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _write_json(output_dir / "phase652_summary.json", result.summary)
+    _write_csv(output_dir / "phase652_metrics.csv", result.metrics)
+    _write_csv(output_dir / "phase652_ablation.csv", result.ablation_rows)
+    _write_csv(output_dir / "phase652_bootstrap.csv", result.bootstrap_rows)
+    _write_csv(output_dir / "phase652_subgroup_stability.csv", result.subgroup_rows)
+    (output_dir / "phase652_findings.md").write_text(_findings_markdown(result))
+
+
+def _build_market_context(
+    train: ComparisonDataset,
+    evaluation: ComparisonDataset,
+    *,
+    c_value: float,
+    folds: int,
+    random_seed: int,
+) -> MarketContext:
+    oof = cross_fitted_market_probabilities(
+        train,
+        c_value=c_value,
+        folds=folds,
+        random_seed=random_seed,
+    )
+    transformer = NumericTransformer.fit(train.market_features)
+    train_values = transformer.transform(train.market_features)
+    evaluation_values = transformer.transform(evaluation.market_features)
+    model = fit_logistic_probability_model(train_values, train.targets, c_value)
+    train_in_sample = predict_positive_probability(model, train_values)
+    evaluation_probabilities = predict_positive_probability(model, evaluation_values)
+    return MarketContext(
+        train_oof_probabilities=oof,
+        train_in_sample_probabilities=train_in_sample,
+        evaluation_probabilities=evaluation_probabilities,
+        constrained_evaluation_probabilities=constrain_probabilities_by_race(
+            evaluation_probabilities,
+            evaluation.race_keys,
+            evaluation.place_slots,
+        ),
+    )
+
+
+def _fit_history_variant(
+    train: ComparisonDataset,
+    evaluation: ComparisonDataset,
+    market_context: MarketContext,
+    subset: FeatureSubset,
+    *,
+    offset_c: float,
+    use_cross_fitted_offset: bool,
+) -> VariantPredictions:
+    train_numeric = train.history_numeric_features[:, subset.numeric_indices]
+    evaluation_numeric = evaluation.history_numeric_features[:, subset.numeric_indices]
+    train_venue = _venue_values(train.venue_codes, subset.use_venue)
+    evaluation_venue = _venue_values(evaluation.venue_codes, subset.use_venue)
+    transformer = HistoryTransformer.fit(train_numeric, train_venue)
+    train_values = transformer.transform(train_numeric, train_venue)
+    evaluation_values = transformer.transform(evaluation_numeric, evaluation_venue)
+    offsets = (
+        market_context.train_oof_probabilities
+        if use_cross_fitted_offset
+        else market_context.train_in_sample_probabilities
+    )
+    model = fit_offset_probability_model(
+        train_values,
+        train.targets,
+        offsets,
+        offset_c,
+    )
+    probabilities = model.predict(
+        evaluation_values,
+        market_context.evaluation_probabilities,
+    )
+    return VariantPredictions(
+        offset=probabilities,
+        constrained_offset=constrain_probabilities_by_race(
+            probabilities,
+            evaluation.race_keys,
+            evaluation.place_slots,
+        ),
+        encoded_feature_count=train_values.shape[1],
+    )
+
+
+def _feature_subset(name: str, *, excluded: Sequence[str]) -> FeatureSubset:
+    excluded_features = {
+        feature for group_name in excluded for feature in FEATURE_GROUPS[group_name]
+    }
+    raw_features = tuple(
+        feature
+        for feature in ("venue_code", *HISTORY_NUMERIC_FEATURE_COLUMNS)
+        if feature not in excluded_features
+    )
+    numeric_indices = tuple(
+        index
+        for index, feature in enumerate(HISTORY_NUMERIC_FEATURE_COLUMNS)
+        if feature in raw_features
+    )
+    return FeatureSubset(
+        name=name,
+        numeric_indices=numeric_indices,
+        raw_feature_names=raw_features,
+        use_venue="venue_code" in raw_features,
+    )
+
+
+def _venue_values(values: ObjectArray, use_venue: bool) -> ObjectArray:
+    if use_venue:
+        return values
+    return np.asarray(["__removed__"] * len(values), dtype=object)
+
+
+def _ablation_row(
+    period_label: str,
+    subset: FeatureSubset,
+    model_kind: str,
+    encoded_feature_count: int,
+    candidate_log_loss: float,
+    full_log_loss: float,
+    market_log_loss: float,
+) -> dict[str, Any]:
+    return {
+        "period_label": period_label,
+        "variant_name": subset.name,
+        "model_kind": model_kind,
+        "raw_feature_count": len(subset.raw_feature_names),
+        "encoded_feature_count": encoded_feature_count,
+        "raw_features": "|".join(subset.raw_feature_names),
+        "log_loss": candidate_log_loss,
+        "delta_vs_full": candidate_log_loss - full_log_loss,
+        "delta_vs_matched_market": candidate_log_loss - market_log_loss,
+    }
+
+
+def _subgroup_masks(
+    dataset: ComparisonDataset,
+) -> tuple[tuple[str, str, NDArray[np.bool_]], ...]:
+    prior_index = HISTORY_NUMERIC_FEATURE_COLUMNS.index("prior_start_count")
+    prior_starts = dataset.history_numeric_features[:, prior_index]
+    popularity = dataset.market_features[:, 2]
+    months = np.asarray([value.month for value in dataset.race_dates], dtype=np.int64)
+    return (
+        ("prior_start_count", "0", prior_starts == 0),
+        ("prior_start_count", "1-2", (prior_starts >= 1) & (prior_starts <= 2)),
+        ("prior_start_count", "3-4", (prior_starts >= 3) & (prior_starts <= 4)),
+        ("prior_start_count", "5+", prior_starts >= 5),
+        ("active_field_size", "5-7", dataset.active_field_sizes <= 7),
+        (
+            "active_field_size",
+            "8-12",
+            (dataset.active_field_sizes >= 8) & (dataset.active_field_sizes <= 12),
+        ),
+        ("active_field_size", "13+", dataset.active_field_sizes >= 13),
+        ("market_popularity", "1-3", popularity <= 3),
+        ("market_popularity", "4-8", (popularity >= 4) & (popularity <= 8)),
+        ("market_popularity", "9+", popularity >= 9),
+        ("half_year", "H1", months <= 6),
+        ("half_year", "H2", months >= 7),
+    )
+
+
+def _robustness_verdict(
+    bootstrap_rows: Sequence[dict[str, Any]],
+) -> tuple[str, list[dict[str, Any]]]:
+    evidence: list[dict[str, Any]] = []
+    evidence_by_candidate: dict[str, dict[str, Any]] = {}
+    for baseline_name, candidate_name in (
+        ("M1_market", "M4_crossfit_full"),
+        ("M1C_race_constrained_market", "M5_crossfit_full"),
+        ("M1_market", "M4_crossfit_history_only"),
+        ("M1C_race_constrained_market", "M5_crossfit_history_only"),
+        ("M1_market", "M4_crossfit_context_only"),
+        ("M1C_race_constrained_market", "M5_crossfit_context_only"),
+    ):
+        rows = [
+            row
+            for row in bootstrap_rows
+            if row["baseline_name"] == baseline_name and row["candidate_name"] == candidate_name
+        ]
+        point_both = len(rows) == 2 and all(
+            float(row["point_log_loss_delta"]) < 0.0 for row in rows
+        )
+        robust_both = point_both and all(float(row["ci95_high"]) < 0.0 for row in rows)
+        candidate_evidence = {
+            "baseline_name": baseline_name,
+            "candidate_name": candidate_name,
+            "point_improvement_in_both_periods": point_both,
+            "bootstrap_ci_below_zero_in_both_periods": robust_both,
+        }
+        evidence.append(candidate_evidence)
+        evidence_by_candidate[candidate_name] = candidate_evidence
+    full_point = all(
+        evidence_by_candidate[name]["point_improvement_in_both_periods"]
+        for name in ("M4_crossfit_full", "M5_crossfit_full")
+    )
+    history_point = all(
+        evidence_by_candidate[name]["point_improvement_in_both_periods"]
+        for name in ("M4_crossfit_history_only", "M5_crossfit_history_only")
+    )
+    full_robust = all(
+        evidence_by_candidate[name]["bootstrap_ci_below_zero_in_both_periods"]
+        for name in ("M4_crossfit_full", "M5_crossfit_full")
+    )
+    history_robust = all(
+        evidence_by_candidate[name]["bootstrap_ci_below_zero_in_both_periods"]
+        for name in ("M4_crossfit_history_only", "M5_crossfit_history_only")
+    )
+    if full_robust and history_robust:
+        return ROBUSTNESS_CONFIRMED, evidence
+    if full_point and history_point:
+        return ROBUSTNESS_DIAGNOSTIC_ONLY, evidence
+    return ROBUSTNESS_NOT_CONFIRMED, evidence
+
+
+def _log_loss(targets: IntArray, probabilities: FloatArray) -> float:
+    return float(log_loss(targets, probabilities, labels=[0, 1]))
+
+
+def _findings_markdown(result: RobustnessResult) -> str:
+    metrics = {(str(row["period_label"]), str(row["model_name"])): row for row in result.metrics}
+    lines = [
+        "# Phase652 Historical Signal Robustness",
+        "",
+        f"Final verdict: `{result.summary['final_verdict']}`",
+        "",
+        "## Fixed-model log loss",
+        "",
+        "| Model | 2024 validation | 2025 reused confirmation |",
+        "|---|---:|---:|",
+    ]
+    for model_name in (
+        "M1_market",
+        "M1C_race_constrained_market",
+        "M4_crossfit_full",
+        "M5_crossfit_full",
+        "M4_in_sample_offset_reference",
+    ):
+        lines.append(
+            f"| `{model_name}` | "
+            f"{metrics[('2024_validation', model_name)]['log_loss']:.6f} | "
+            f"{metrics[('2025_reused_confirmation', model_name)]['log_loss']:.6f} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Overall paired-bootstrap deltas",
+            "",
+            "| Candidate vs baseline | 2024 validation | 2025 reused confirmation |",
+            "|---|---:|---:|",
+        ]
+    )
+    bootstrap = {
+        (
+            str(row["period_label"]),
+            str(row["baseline_name"]),
+            str(row["candidate_name"]),
+        ): row
+        for row in result.bootstrap_rows
+    }
+    for baseline_name, candidate_name in (
+        ("M1_market", "M4_crossfit_full"),
+        ("M1C_race_constrained_market", "M5_crossfit_full"),
+        ("M1_market", "M4_crossfit_history_only"),
+        ("M1C_race_constrained_market", "M5_crossfit_history_only"),
+        ("M1_market", "M4_crossfit_context_only"),
+        ("M1C_race_constrained_market", "M5_crossfit_context_only"),
+        ("M4_in_sample_offset_reference", "M4_crossfit_full"),
+    ):
+        row_2024 = bootstrap[("2024_validation", baseline_name, candidate_name)]
+        row_2025 = bootstrap[("2025_reused_confirmation", baseline_name, candidate_name)]
+        lines.append(
+            f"| `{candidate_name}` vs `{baseline_name}` | "
+            f"{float(row_2024['point_log_loss_delta']):+.6f} | "
+            f"{float(row_2025['point_log_loss_delta']):+.6f} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Supported failure pockets",
+            "",
+        ]
+    )
+    failure_pockets = result.summary["supported_failure_pockets"]
+    if failure_pockets:
+        for row in failure_pockets:
+            lines.append(
+                "- "
+                f"`{row['period_label']}` `{row['model_name']}` "
+                f"{row['dimension']}={row['subgroup']}: "
+                f"delta {float(row['point_log_loss_delta']):+.6f}, "
+                f"95% CI [{float(row['ci95_low']):+.6f}, "
+                f"{float(row['ci95_high']):+.6f}]."
+            )
+    else:
+        lines.append("- None detected under the configured subgroup threshold.")
+    lines.extend(
+        [
+            "",
+            "## Interpretation boundary",
+            "",
+            "- Phase651 hyperparameters are frozen.",
+            "- 2025 has already been observed and is not presented as a fresh holdout.",
+            "- Ablations and subgroups are diagnostic; none selects a betting rule.",
+            "- ROI, payout, stake, and threshold logic remain out of scope.",
+            f"- Operational recommendation: `{result.summary['operational_recommendation']}`.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n")
+
+
+def _write_csv(path: Path, rows: Iterable[dict[str, Any]]) -> None:
+    materialized = list(rows)
+    if not materialized:
+        raise ValueError(f"cannot write empty CSV: {path}")
+    with path.open("w", newline="") as file_handle:
+        writer = csv.DictWriter(file_handle, fieldnames=list(materialized[0]))
+        writer.writeheader()
+        writer.writerows(materialized)

--- a/tests/test_historical_signal_robustness.py
+++ b/tests/test_historical_signal_robustness.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+from pathlib import Path
+
+import numpy as np
+
+from horse_bet_lab.research.historical_ability_models import (
+    HISTORY_NUMERIC_FEATURE_COLUMNS,
+    ComparisonDataset,
+    place_slots_for_field_size,
+)
+from horse_bet_lab.research.historical_signal_robustness import (
+    FEATURE_GROUPS,
+    cross_fitted_market_probabilities,
+    feature_subsets,
+    run_signal_robustness,
+    write_robustness_result,
+)
+
+
+def test_feature_groups_cover_phase651_history_contract() -> None:
+    grouped = {feature for values in FEATURE_GROUPS.values() for feature in values}
+    assert grouped == {"venue_code", *HISTORY_NUMERIC_FEATURE_COLUMNS}
+    subsets = {subset.name: subset for subset in feature_subsets()}
+    assert "last_3_top3_rate" not in subsets["without_recent_form"].raw_feature_names
+    assert (
+        "last_5_venue_compatibility_rate" not in subsets["without_compatibility"].raw_feature_names
+    )
+    assert subsets["without_current_context"].use_venue is False
+    assert subsets["current_context_only"].raw_feature_names == (
+        "venue_code",
+        "current_distance_m",
+        "card_field_size",
+    )
+
+
+def test_cross_fitted_market_probabilities_are_complete_and_deterministic() -> None:
+    dataset = _synthetic_dataset(years=(2023,), races_per_year=12)
+
+    first = cross_fitted_market_probabilities(dataset, folds=3, random_seed=11)
+    second = cross_fitted_market_probabilities(dataset, folds=3, random_seed=11)
+
+    assert np.all(np.isfinite(first))
+    assert np.all((first > 0.0) & (first < 1.0))
+    assert np.array_equal(first, second)
+
+
+def test_robustness_run_keeps_2025_as_reused_confirmation() -> None:
+    dataset = _synthetic_dataset(years=(2023, 2024, 2025), races_per_year=14)
+
+    result = run_signal_robustness(
+        dataset,
+        crossfit_folds=3,
+        bootstrap_repetitions=50,
+        subgroup_bootstrap_repetitions=20,
+        minimum_subgroup_rows=10,
+    )
+
+    assert result.summary["period_contract"]["2025"].startswith("reused confirmation")
+    assert result.summary["feature_ablation_used_for_selection"] is False
+    assert result.summary["roi_or_betting_used"] is False
+    assert result.summary["operational_recommendation"] == (
+        "RETAIN_AS_PROBABILITY_DIAGNOSTIC_NOT_BETTING_RULE"
+    )
+    assert result.summary["uniform_subgroup_improvement_supported"] is False
+    assert {row["model_name"] for row in result.metrics} == {
+        "M1_market",
+        "M1C_race_constrained_market",
+        "M4_crossfit_full",
+        "M5_crossfit_full",
+        "M4_in_sample_offset_reference",
+    }
+    assert len(result.ablation_rows) == 24
+    assert len(result.bootstrap_rows) == 14
+    assert result.subgroup_rows
+
+
+def test_robustness_writer_emits_only_diagnostic_outputs(tmp_path: Path) -> None:
+    dataset = _synthetic_dataset(years=(2023, 2024, 2025), races_per_year=10)
+    result = run_signal_robustness(
+        dataset,
+        crossfit_folds=2,
+        bootstrap_repetitions=20,
+        subgroup_bootstrap_repetitions=10,
+        minimum_subgroup_rows=10,
+    )
+    output_dir = tmp_path / "reports"
+
+    write_robustness_result(result, output_dir)
+
+    assert {path.name for path in output_dir.iterdir()} == {
+        "phase652_summary.json",
+        "phase652_metrics.csv",
+        "phase652_ablation.csv",
+        "phase652_bootstrap.csv",
+        "phase652_subgroup_stability.csv",
+        "phase652_findings.md",
+    }
+    assert not any("roi" in path.name or "bet" in path.name for path in output_dir.iterdir())
+
+
+def _synthetic_dataset(
+    *,
+    years: tuple[int, ...],
+    races_per_year: int,
+    field_size: int = 8,
+) -> ComparisonDataset:
+    race_dates: list[date] = []
+    race_keys: list[str] = []
+    horse_numbers: list[int] = []
+    targets: list[int] = []
+    market_features: list[list[float]] = []
+    history_features: list[list[float]] = []
+    venue_codes: list[str] = []
+    active_sizes: list[int] = []
+    place_slots: list[int] = []
+    for year in years:
+        for race_index in range(races_per_year):
+            race_date = date(year, 1, 1) + timedelta(days=15 * race_index)
+            race_key = f"{year}{race_index:04d}"
+            latent_rows: list[tuple[int, float, float, float]] = []
+            for horse_number in range(1, field_size + 1):
+                history_signal = ((horse_number * 7 + race_index * 3) % field_size) / field_size
+                market_signal = ((horse_number * 5 + race_index) % field_size) / field_size
+                latent = 2.0 * history_signal + 0.8 * market_signal
+                latent_rows.append((horse_number, latent, history_signal, market_signal))
+            placed = {
+                horse_number
+                for horse_number, _, _, _ in sorted(
+                    latent_rows,
+                    key=lambda value: value[1],
+                    reverse=True,
+                )[: place_slots_for_field_size(field_size)]
+            }
+            for horse_number, _, history_signal, market_signal in latent_rows:
+                prior_starts = (horse_number + race_index) % 10
+                race_dates.append(race_date)
+                race_keys.append(race_key)
+                horse_numbers.append(horse_number)
+                targets.append(int(horse_number in placed))
+                market_features.append(
+                    [
+                        np.log1p(2.0 + 8.0 * (1.0 - market_signal)),
+                        np.log1p(1.2 + 3.0 * (1.0 - market_signal)),
+                        float(1 + int((1.0 - market_signal) * field_size)),
+                    ]
+                )
+                history_features.append(
+                    [
+                        1600.0 + 200.0 * (race_index % 3),
+                        float(field_size),
+                        float(prior_starts),
+                        20.0 + horse_number if prior_starts else np.nan,
+                        history_signal if prior_starts else np.nan,
+                        history_signal if prior_starts else np.nan,
+                        history_signal if prior_starts else np.nan,
+                        history_signal if prior_starts else np.nan,
+                        history_signal if prior_starts else np.nan,
+                        history_signal if prior_starts else np.nan,
+                        0.5 if prior_starts else np.nan,
+                        0.5 if prior_starts else np.nan,
+                    ]
+                )
+                venue_codes.append(f"{1 + race_index % 3:02d}")
+                active_sizes.append(field_size)
+                place_slots.append(place_slots_for_field_size(field_size))
+    target_array = np.asarray(targets, dtype=np.int64)
+    return ComparisonDataset(
+        race_dates=tuple(race_dates),
+        race_keys=np.asarray(race_keys, dtype=object),
+        horse_numbers=np.asarray(horse_numbers, dtype=np.int64),
+        targets=target_array,
+        market_targets=target_array.copy(),
+        market_features=np.asarray(market_features, dtype=np.float64),
+        history_numeric_features=np.asarray(history_features, dtype=np.float64),
+        venue_codes=np.asarray(venue_codes, dtype=object),
+        active_field_sizes=np.asarray(active_sizes, dtype=np.int64),
+        place_slots=np.asarray(place_slots, dtype=np.int64),
+    )


### PR DESCRIPTION
## What changed

- add a five-fold race-group cross-fit contract for the frozen Phase651 market offset;
- separate strictly-prior horse-history residual signal from current race context;
- add leave-one-feature-group-out diagnostics and subgroup stability slices;
- preserve 2025 as a reused confirmation period rather than presenting it as a fresh holdout;
- emit paired race-bootstrap evidence, supported failure pockets, and a research-only recommendation;
- expose small public wrappers around the frozen Phase651 logistic model family for reuse without duplicating private implementation.

## Why

Phase651 showed a small improvement after adding historical features, but the original comparison did not prove that the gain came from horse history rather than shared race context, and its stacking contract used in-sample market probabilities for residual training. Phase652 re-tests that hypothesis with out-of-fold market offsets and targeted controls.

## Result

- overall full residual models improve matched market baselines in 2024 and reused 2025 confirmation;
- history-only residuals improve point Log Loss in both periods;
- constrained history-only 2024 is borderline: its 95% bootstrap interval reaches `+0.000001`;
- 5-7 runner fields are a supported harmful pocket;
- final verdict: `HISTORY_SIGNAL_CROSSFIT_DIAGNOSTIC_ONLY`;
- operational recommendation: `RETAIN_AS_PROBABILITY_DIAGNOSTIC_NOT_BETTING_RULE`.

No ROI, payout, threshold, candidate, BET, final-odds, CLI, or runner behavior is changed. Generated reports remain ignored.

## Validation

- Ruff format/check: passed
- Mypy on changed source/script: passed
- `pytest` Phase650H/651/652 related tests: `14 passed`
- `compileall src scripts tests`: passed
- real-data execution: passed
- summary JSON validation: passed
- deterministic rerun: all six generated report hashes matched
