### PR TITLE
Phase655: audit prospective collection readiness

### DIFF
--- a/docs/phase655_forward_collection_readiness.md
+++ b/docs/phase655_forward_collection_readiness.md
@@ -1,0 +1,62 @@
+# Phase655 Forward Collection Readiness
+
+## Purpose
+
+Phase654 registered a prospective 2026-07-20 through 2026-12-31 evaluation window and locked
+model evaluation until 2027-01-01. Phase655 checks only whether the existing repository contracts
+can collect and later reproduce every fixed input. It does not inspect forward-window files or
+compute model results.
+
+## Confirmed collection paths
+
+- BAC, KYI, OZ, and SED are supported raw file kinds.
+- Triggered JRDB archive ingestion preserves extracted raw files and can hand supported records to
+  staging.
+- Phase650H accepts explicit history and evaluation years, so its strictly-prior history surface
+  can be rebuilt after the evaluation period and result files arrive.
+- The Phase650H surface contains every historical feature required by Phase651.
+- Phase654's checksum, dates, fixed models, comparisons, and metric gates validate.
+
+## Blocking mismatch
+
+The fixed Phase651 `dual_market` input contains:
+
+- `win_odds`;
+- `place_basis_odds`;
+- `popularity`.
+
+The current dataset query obtains popularity from result-side SED. The forward-test contract,
+however, defines popularity as optional `unresolved_auxiliary`; it is not a confirmed pre-race
+carrier. Consequently the exact fixed market baseline cannot currently substantiate its
+"decision-time market" description in prospective collection.
+
+This is not a missing-row problem that can be patched after collection. It is a feature-timing and
+carrier-equivalence problem.
+
+## Verdict
+
+`FORWARD_COLLECTION_READINESS_BLOCKED`
+
+Collection must not be called model-ready until one of these paths is chosen before forward model
+results are inspected:
+
+1. confirm and snapshot a pre-race popularity carrier equivalent to the Phase651 feature; or
+2. preregister a no-popularity baseline and repeat the 2023-2025 probability research with that
+   fixed feature contract before using the forward window.
+
+Phase655 does not choose between those paths and does not change the model.
+
+## Safety boundary
+
+This audit reads code and committed contracts only. It does not read raw source contents, count
+forward rows, condition diagnostics on outcomes, produce predictions or probability metrics, or
+touch ROI, payout, selection, threshold, stake, or BET logic.
+
+## Execution
+
+```bash
+PYTHONPATH=src .venv/bin/python scripts/phase655_forward_collection_readiness.py
+```
+
+The expected non-zero process exit reflects the blocked readiness verdict. Generated reports
+remain under `data/artifacts/` and are not committed.

--- a/scripts/phase655_forward_collection_readiness.py
+++ b/scripts/phase655_forward_collection_readiness.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from horse_bet_lab.research.forward_collection_readiness import (
+    BLOCKED_VERDICT,
+    run_forward_collection_readiness,
+    write_forward_collection_readiness,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Audit static readiness for the Phase654 prospective collection window.",
+    )
+    parser.add_argument(
+        "--contract",
+        type=Path,
+        default=Path("configs/phase654_2026_forward_preregistered_validation.json"),
+    )
+    parser.add_argument(
+        "--checksum",
+        type=Path,
+        default=Path("configs/phase654_2026_forward_preregistered_validation.sha256"),
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("data/artifacts/phase655_forward_collection_readiness"),
+    )
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    result = run_forward_collection_readiness(
+        contract_path=args.contract,
+        checksum_path=args.checksum,
+    )
+    write_forward_collection_readiness(result, args.output_dir)
+    print(json.dumps(result.summary, ensure_ascii=False, indent=2, sort_keys=True))
+    return int(result.summary["final_verdict"] == BLOCKED_VERDICT)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/horse_bet_lab/research/forward_collection_readiness.py
+++ b/src/horse_bet_lab/research/forward_collection_readiness.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import csv
+import inspect
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+from horse_bet_lab.dataset.service import market_feature_select_parts
+from horse_bet_lab.features.registry import dataset_feature_columns
+from horse_bet_lab.forward_test.contracts import (
+    PLACE_FORWARD_TEST_POPULARITY_CONTRACT_STATUS,
+)
+from horse_bet_lab.ingest.specs import SUPPORTED_FILE_SPECS
+from horse_bet_lab.jrdb_ingestion.orchestration import run_jrdb_auto_ingestion_job
+from horse_bet_lab.research.historical_ability_models import (
+    HISTORY_CATEGORICAL_FEATURE_COLUMNS,
+    HISTORY_NUMERIC_FEATURE_COLUMNS,
+)
+from horse_bet_lab.research.historical_ability_source import (
+    MODEL_FEATURE_COLUMNS,
+    build_source_audit,
+)
+from horse_bet_lab.research.preregistered_validation_contract import (
+    VALID_VERDICT as PREREGISTRATION_VALID_VERDICT,
+)
+from horse_bet_lab.research.preregistered_validation_contract import (
+    load_registered_contract,
+)
+
+READY_VERDICT = "FORWARD_COLLECTION_READINESS_READY"
+BLOCKED_VERDICT = "FORWARD_COLLECTION_READINESS_BLOCKED"
+
+REQUIRED_RAW_FILE_KINDS = ("BAC", "KYI", "OZ", "SED")
+REQUIRED_MARKET_FEATURES = ("win_odds", "place_basis_odds", "popularity")
+CONFIRMED_FORWARD_POPULARITY_STATUS = "confirmed_pre_race_carrier"
+CONFIRMED_FORWARD_POPULARITY_ORIGIN = "confirmed_pre_race_snapshot"
+
+
+@dataclass(frozen=True)
+class ForwardCollectionReadinessResult:
+    summary: dict[str, Any]
+    checks: tuple[dict[str, Any], ...]
+
+
+def run_forward_collection_readiness(
+    *,
+    contract_path: Path,
+    checksum_path: Path,
+    popularity_contract_status_override: str | None = None,
+    popularity_origin_override: str | None = None,
+) -> ForwardCollectionReadinessResult:
+    registration = load_registered_contract(contract_path, checksum_path)
+    contract = registration.payload
+    checks: list[dict[str, Any]] = []
+    blockers: list[str] = []
+
+    _append_check(
+        checks,
+        check_id="phase654_contract_locked",
+        passed=registration.summary["verdict"] == PREREGISTRATION_VALID_VERDICT,
+        evidence=f"sha256={registration.sha256}",
+    )
+
+    supported_file_kinds = {spec.file_kind for spec in SUPPORTED_FILE_SPECS}
+    raw_kinds_present = set(REQUIRED_RAW_FILE_KINDS).issubset(supported_file_kinds)
+    _append_check(
+        checks,
+        check_id="required_raw_file_kinds_supported",
+        passed=raw_kinds_present,
+        evidence=f"required={list(REQUIRED_RAW_FILE_KINDS)}",
+    )
+    if not raw_kinds_present:
+        missing = sorted(set(REQUIRED_RAW_FILE_KINDS) - supported_file_kinds)
+        blockers.append(f"missing raw file specifications: {missing}")
+
+    source_parameters = inspect.signature(build_source_audit).parameters
+    history_builder_parameterized = {
+        "raw_root",
+        "history_years",
+        "evaluation_years",
+        "minimum_identity_match_rate",
+    }.issubset(source_parameters)
+    phase651_history_features = {
+        *HISTORY_NUMERIC_FEATURE_COLUMNS,
+        *HISTORY_CATEGORICAL_FEATURE_COLUMNS,
+    }
+    history_surface_compatible = phase651_history_features.issubset(MODEL_FEATURE_COLUMNS)
+    history_rebuild_ready = history_builder_parameterized and history_surface_compatible
+    _append_check(
+        checks,
+        check_id="post_period_history_surface_rebuild",
+        passed=history_rebuild_ready,
+        evidence=(
+            f"parameterized={history_builder_parameterized}; "
+            f"phase651_features_present={history_surface_compatible}"
+        ),
+    )
+    if not history_rebuild_ready:
+        blockers.append("Phase650H history surface cannot be rebuilt for a later evaluation year")
+
+    ingestion_framework_present = callable(run_jrdb_auto_ingestion_job)
+    _append_check(
+        checks,
+        check_id="raw_archive_ingestion_framework_present",
+        passed=ingestion_framework_present,
+        evidence="triggered archive download, extraction, raw placement, and ingest handoff exist",
+    )
+    if not ingestion_framework_present:
+        blockers.append("raw archive ingestion framework is unavailable")
+
+    market_features = dataset_feature_columns("dual_market")
+    market_feature_contract_matches = market_features == REQUIRED_MARKET_FEATURES
+    _append_check(
+        checks,
+        check_id="fixed_market_feature_contract_identified",
+        passed=market_feature_contract_matches,
+        evidence=f"dual_market_features={list(market_features)}",
+    )
+    if not market_feature_contract_matches:
+        blockers.append("fixed Phase651 dual-market feature contract changed")
+
+    market_sql = market_feature_select_parts(
+        "dual_market",
+        {"popularity": "popularity"},
+        {"place_basis_odds": "place_basis_odds"},
+    )
+    detected_popularity_origin = (
+        "result_side_sed"
+        if any("r.popularity" in expression for expression in market_sql)
+        else "unknown"
+    )
+    popularity_origin = popularity_origin_override or detected_popularity_origin
+    popularity_status = (
+        popularity_contract_status_override or PLACE_FORWARD_TEST_POPULARITY_CONTRACT_STATUS
+    )
+    popularity_carrier_ready = (
+        popularity_status == CONFIRMED_FORWARD_POPULARITY_STATUS
+        and popularity_origin == CONFIRMED_FORWARD_POPULARITY_ORIGIN
+    )
+    _append_check(
+        checks,
+        check_id="decision_time_popularity_carrier_confirmed",
+        passed=popularity_carrier_ready,
+        evidence=f"status={popularity_status}; origin={popularity_origin}",
+    )
+    if not popularity_carrier_ready:
+        blockers.append(
+            "fixed Phase651 market baseline requires popularity, but no confirmed equivalent "
+            "decision-time popularity carrier exists"
+        )
+    if popularity_origin == "result_side_sed":
+        blockers.append(
+            "current dual-market dataset obtains popularity from result-side SED, so it cannot "
+            "substantiate the registered decision-time-market claim"
+        )
+
+    periods = contract["periods"]
+    _append_check(
+        checks,
+        check_id="prospective_window_and_unlock_fixed",
+        passed=(
+            periods["evaluation_start"] == "2026-07-20"
+            and periods["evaluation_end"] == "2026-12-31"
+            and periods["evaluation_unlock_date"] == "2027-01-01"
+        ),
+        evidence=(
+            f"window={periods['evaluation_start']}..{periods['evaluation_end']}; "
+            f"unlock={periods['evaluation_unlock_date']}"
+        ),
+    )
+
+    final_verdict = READY_VERDICT if not blockers else BLOCKED_VERDICT
+    summary = {
+        "final_verdict": final_verdict,
+        "phase654_contract_sha256": registration.sha256,
+        "evaluation_window": {
+            "start": periods["evaluation_start"],
+            "end": periods["evaluation_end"],
+            "unlock_date": periods["evaluation_unlock_date"],
+        },
+        "required_raw_file_kinds": list(REQUIRED_RAW_FILE_KINDS),
+        "fixed_market_features": list(market_features),
+        "history_surface_rebuild_ready": history_rebuild_ready,
+        "raw_archive_ingestion_framework_present": ingestion_framework_present,
+        "detected_popularity_origin": detected_popularity_origin,
+        "forward_popularity_contract_status": popularity_status,
+        "decision_time_popularity_carrier_ready": popularity_carrier_ready,
+        "blockers": blockers,
+        "source_content_inspected": False,
+        "forward_rows_or_coverage_inspected": False,
+        "model_predictions_or_metrics_computed": False,
+        "outcome_conditioning_used": False,
+        "roi_or_betting_used": False,
+        "recommendation": (
+            "RESOLVE_POPULARITY_CARRIER_OR_PREREGISTER_AND_REBASE_WITHOUT_POPULARITY"
+            if blockers
+            else "BEGIN_PROSPECTIVE_NON_OUTCOME_CONDITIONED_COLLECTION_MONITORING"
+        ),
+    }
+    return ForwardCollectionReadinessResult(summary=summary, checks=tuple(checks))
+
+
+def write_forward_collection_readiness(
+    result: ForwardCollectionReadinessResult,
+    output_dir: Path,
+) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "phase655_summary.json").write_text(
+        json.dumps(result.summary, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    _write_csv(output_dir / "phase655_checks.csv", result.checks)
+    (output_dir / "phase655_findings.md").write_text(
+        _findings_markdown(result),
+        encoding="utf-8",
+    )
+
+
+def _append_check(
+    rows: list[dict[str, Any]],
+    *,
+    check_id: str,
+    passed: bool,
+    evidence: str,
+) -> None:
+    rows.append(
+        {
+            "check_id": check_id,
+            "status": "PASS" if passed else "FAIL",
+            "evidence": evidence,
+        }
+    )
+
+
+def _write_csv(path: Path, rows: Sequence[dict[str, Any]]) -> None:
+    fieldnames = list(rows[0]) if rows else []
+    with path.open("w", encoding="utf-8", newline="") as file:
+        if not fieldnames:
+            return
+        writer = csv.DictWriter(file, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _findings_markdown(result: ForwardCollectionReadinessResult) -> str:
+    lines = [
+        "# Phase655 Forward Collection Readiness",
+        "",
+        "## Final verdict",
+        "",
+        f"`{result.summary['final_verdict']}`",
+        "",
+        "## Confirmed paths",
+        "",
+        "- Raw BAC, KYI, OZ, and SED file specifications exist.",
+        "- The archive ingestion framework can preserve and ingest raw files.",
+        (
+            "- Phase650H can be parameterized for a later evaluation year and rebuilt "
+            "after results arrive."
+        ),
+        "- Phase654 keeps model evaluation locked until 2027-01-01.",
+        "",
+        "## Blocking mismatch",
+        "",
+        "The fixed Phase651 market baseline requires popularity. The current dataset obtains that "
+        "field from result-side SED, while the forward-test contract explicitly treats popularity "
+        "as unresolved auxiliary input. Therefore the registered decision-time market surface "
+        "cannot yet be reproduced prospectively with equivalent features.",
+        "",
+        "## Boundary",
+        "",
+        "No raw source content, forward-window rows, outcomes, predictions, metrics, ROI, payouts, "
+        "or betting rules were inspected or computed in this audit.",
+        "",
+        "## Next decision",
+        "",
+        "Before collection is called ready, either confirm and snapshot an equivalent pre-race "
+        "popularity carrier, or preregister a no-popularity baseline and rerun the 2023-2025 "
+        "probability research under that new fixed feature contract.",
+        "",
+    ]
+    return "\n".join(lines)

--- a/tests/test_forward_collection_readiness.py
+++ b/tests/test_forward_collection_readiness.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from horse_bet_lab.research.forward_collection_readiness import (
+    BLOCKED_VERDICT,
+    CONFIRMED_FORWARD_POPULARITY_ORIGIN,
+    CONFIRMED_FORWARD_POPULARITY_STATUS,
+    READY_VERDICT,
+    run_forward_collection_readiness,
+    write_forward_collection_readiness,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT_PATH = ROOT / "configs/phase654_2026_forward_preregistered_validation.json"
+CHECKSUM_PATH = ROOT / "configs/phase654_2026_forward_preregistered_validation.sha256"
+
+
+def test_current_contract_is_blocked_by_unconfirmed_popularity_carrier() -> None:
+    result = run_forward_collection_readiness(
+        contract_path=CONTRACT_PATH,
+        checksum_path=CHECKSUM_PATH,
+    )
+
+    assert result.summary["final_verdict"] == BLOCKED_VERDICT
+    assert result.summary["history_surface_rebuild_ready"] is True
+    assert result.summary["raw_archive_ingestion_framework_present"] is True
+    assert result.summary["fixed_market_features"] == [
+        "win_odds",
+        "place_basis_odds",
+        "popularity",
+    ]
+    assert result.summary["detected_popularity_origin"] == "result_side_sed"
+    assert result.summary["decision_time_popularity_carrier_ready"] is False
+    assert any("popularity" in blocker for blocker in result.summary["blockers"])
+    assert result.summary["source_content_inspected"] is False
+    assert result.summary["model_predictions_or_metrics_computed"] is False
+    assert result.summary["roi_or_betting_used"] is False
+
+
+def test_confirmed_equivalent_popularity_carrier_would_clear_static_gate() -> None:
+    result = run_forward_collection_readiness(
+        contract_path=CONTRACT_PATH,
+        checksum_path=CHECKSUM_PATH,
+        popularity_contract_status_override=CONFIRMED_FORWARD_POPULARITY_STATUS,
+        popularity_origin_override=CONFIRMED_FORWARD_POPULARITY_ORIGIN,
+    )
+
+    assert result.summary["final_verdict"] == READY_VERDICT
+    assert result.summary["decision_time_popularity_carrier_ready"] is True
+    assert result.summary["blockers"] == []
+
+
+def test_writer_emits_only_static_diagnostic_artifacts(tmp_path: Path) -> None:
+    result = run_forward_collection_readiness(
+        contract_path=CONTRACT_PATH,
+        checksum_path=CHECKSUM_PATH,
+    )
+    output_dir = tmp_path / "reports"
+
+    write_forward_collection_readiness(result, output_dir)
+
+    assert {path.name for path in output_dir.iterdir()} == {
+        "phase655_summary.json",
+        "phase655_checks.csv",
+        "phase655_findings.md",
+    }
+    assert not any(
+        forbidden in path.name
+        for path in output_dir.iterdir()
+        for forbidden in ("prediction", "metric", "roi", "payout", "bet")
+    )


### PR DESCRIPTION
## What changed

- add a static Phase655 readiness audit for the Phase654 prospective evaluation window
- verify the committed preregistration, supported raw file kinds, ingestion framework, and post-period Phase650H rebuild path
- detect whether the fixed Phase651 dual-market inputs have equivalent decision-time carriers
- emit summary, check, and findings artifacts without reading forward data or computing model results

## Why

Phase654 fixed a prospective 2026-07-20 through 2026-12-31 evaluation window. Before calling collection model-ready, every frozen input must be reproducible at decision time.

The audit finds a methodological blocker: the fixed Phase651 dual-market baseline requires `popularity`, while the current dataset query obtains it from result-side SED and the forward-test contract still marks the carrier as unresolved auxiliary input.

## Impact

The readiness verdict is intentionally:

`FORWARD_COLLECTION_READINESS_BLOCKED`

This PR does not change models, collection behavior, thresholds, staking, ROI logic, or BET logic. It records the blocker before forward outcomes are available.

The next research decision is either:

1. confirm and snapshot an equivalent pre-race popularity carrier; or
2. preregister a no-popularity baseline and rerun the 2023-2025 probability research before using the forward window.

## Validation

- 24 relevant tests passed
- Ruff check passed
- Ruff format check passed
- strict Mypy passed
- compileall passed
- summary JSON validated
- executable returns the expected non-zero exit for the blocked verdict
