### PR TITLE
Phase656: compare safe popularity feature contracts

### DIFF
--- a/docs/phase656_popularity_carrier_comparison.md
+++ b/docs/phase656_popularity_carrier_comparison.md
@@ -1,0 +1,54 @@
+# Phase656 Popularity Carrier Comparison
+
+## Purpose
+
+Phase655 showed that the frozen Phase651 market baseline cannot be reproduced prospectively as
+written: it uses popularity from result-side SED, while the forward contract has no confirmed
+decision-time popularity carrier.
+
+Phase656 compares safe replacements before changing Phase654. It uses only the established
+2023-2025 historical surface; no 2026 row is read.
+
+## Fixed variants
+
+| Variant | Features | Role |
+|---|---|---|
+| `legacy_result_popularity` | log win odds, log place-basis odds, SED popularity | invalid prospective comparator only |
+| `no_popularity` | log win odds, log place-basis odds | safe candidate |
+| `decision_time_win_rank` | log win odds, log place-basis odds, midrank derived from observed win odds | safe candidate |
+
+Equal visible win odds receive the same midrank. Horse number is not used as an artificial
+tie-breaker.
+
+## Selection and evaluation
+
+- train each logistic market model on 2023;
+- select regularization separately for each variant on 2024;
+- select between the two safe variants using 2024 constrained-market (`M1C`) binary Log Loss;
+- refit on 2023-2024;
+- report 2025 once after selection.
+
+The 2025 period is called historical evaluation, not a fresh holdout. It has already been inspected
+by earlier phases, even though the safe popularity variants were not previously compared this way.
+
+Race-level paired bootstrap deltas compare both safe candidates with the legacy diagnostic and
+compare the two safe candidates directly. No ROI measure selects a model.
+
+## Interpretation boundary
+
+Historical accuracy cannot make result-side SED popularity eligible for a prospective feature.
+The legacy variant is excluded from safe-candidate selection regardless of its score.
+
+Phase656 selects a candidate for a new preregistration. It does not edit Phase654 and does not yet
+rerun the full Phase651-653 history-residual and small-field research. That rerun is the next gate.
+
+## Execution
+
+```bash
+PYTHONPATH=src .venv/bin/python scripts/phase656_popularity_carrier_comparison.py \
+  --history-surface /absolute/path/phase650h_history_surface.csv \
+  --source-summary /absolute/path/phase650h_source_summary.json \
+  --market-dataset /absolute/path/dual_market_logreg/dataset.parquet
+```
+
+Generated artifacts remain under `data/artifacts/` and are not committed.

--- a/scripts/phase656_popularity_carrier_comparison.py
+++ b/scripts/phase656_popularity_carrier_comparison.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from horse_bet_lab.research.historical_ability_models import load_comparison_dataset
+from horse_bet_lab.research.popularity_carrier_comparison import (
+    run_popularity_carrier_comparison,
+    write_popularity_carrier_comparison,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Compare decision-time-safe replacements for legacy SED popularity.",
+    )
+    parser.add_argument("--history-surface", type=Path, required=True)
+    parser.add_argument("--source-summary", type=Path, required=True)
+    parser.add_argument("--market-dataset", type=Path, required=True)
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("data/artifacts/phase656_popularity_carrier_comparison"),
+    )
+    parser.add_argument("--bootstrap-repetitions", type=int, default=2_000)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    dataset, input_audit = load_comparison_dataset(
+        history_surface_path=args.history_surface,
+        source_summary_path=args.source_summary,
+        market_dataset_path=args.market_dataset,
+    )
+    result = run_popularity_carrier_comparison(
+        dataset,
+        input_audit,
+        bootstrap_repetitions=args.bootstrap_repetitions,
+    )
+    write_popularity_carrier_comparison(result, args.output_dir)
+    print(json.dumps(result.summary, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/horse_bet_lab/research/popularity_carrier_comparison.py
+++ b/src/horse_bet_lab/research/popularity_carrier_comparison.py
@@ -1,0 +1,508 @@
+from __future__ import annotations
+
+import csv
+import json
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any, Sequence
+
+import numpy as np
+from numpy.typing import NDArray
+from sklearn.metrics import log_loss  # type: ignore[import-untyped]
+
+from horse_bet_lab.research.historical_ability_models import (
+    DEFAULT_C_GRID,
+    ComparisonDataset,
+    InputAudit,
+    NumericTransformer,
+    constrain_probabilities_by_race,
+    fit_logistic_probability_model,
+    metric_row,
+    predict_positive_probability,
+    race_bootstrap_log_loss_delta,
+)
+
+LEGACY_RESULT_POPULARITY = "legacy_result_popularity"
+NO_POPULARITY = "no_popularity"
+DECISION_TIME_WIN_RANK = "decision_time_win_rank"
+SAFE_VARIANTS = (NO_POPULARITY, DECISION_TIME_WIN_RANK)
+ALL_VARIANTS = (LEGACY_RESULT_POPULARITY, *SAFE_VARIANTS)
+
+FINAL_VERDICT = "DECISION_TIME_MARKET_FEATURE_CANDIDATE_SELECTED"
+SEMANTIC_VERDICT = "RESULT_SIDE_POPULARITY_NOT_PROSPECTIVE_SAFE"
+
+FloatArray = NDArray[np.float64]
+
+
+@dataclass(frozen=True)
+class PopularityCarrierComparisonResult:
+    summary: dict[str, Any]
+    metrics: tuple[dict[str, Any], ...]
+    bootstrap_rows: tuple[dict[str, Any], ...]
+    rank_agreement_rows: tuple[dict[str, Any], ...]
+    hyperparameter_rows: tuple[dict[str, Any], ...]
+
+
+@dataclass(frozen=True)
+class _VariantFit:
+    selected_c: float
+    validation_raw: FloatArray
+    validation_constrained: FloatArray
+    holdout_raw: FloatArray
+    holdout_constrained: FloatArray
+    metrics: tuple[dict[str, Any], ...]
+    hyperparameters: tuple[dict[str, Any], ...]
+
+
+def market_variant_dataset(dataset: ComparisonDataset, variant: str) -> ComparisonDataset:
+    if variant not in ALL_VARIANTS:
+        raise ValueError(f"unsupported market variant: {variant}")
+    if dataset.market_features.ndim != 2 or dataset.market_features.shape[1] != 3:
+        raise ValueError(
+            "Phase656 expects Phase651 market features in "
+            "(log win odds, log place-basis odds, legacy popularity) order"
+        )
+    base_market = np.asarray(dataset.market_features[:, :2], dtype=np.float64)
+    if variant == LEGACY_RESULT_POPULARITY:
+        features = np.asarray(dataset.market_features, dtype=np.float64).copy()
+    elif variant == NO_POPULARITY:
+        features = base_market.copy()
+    else:
+        decision_time_rank = decision_time_win_midranks(
+            dataset.market_features[:, 0],
+            dataset.race_keys,
+        )
+        features = np.concatenate([base_market, decision_time_rank.reshape(-1, 1)], axis=1)
+    return replace(dataset, market_features=features)
+
+
+def decision_time_win_midranks(
+    log_win_odds: FloatArray,
+    race_keys: NDArray[np.object_],
+) -> FloatArray:
+    if len(log_win_odds) != len(race_keys):
+        raise ValueError("win odds and race keys must have the same row count")
+    ranks = np.empty(len(log_win_odds), dtype=np.float64)
+    groups: dict[str, list[int]] = {}
+    for index, race_key in enumerate(race_keys):
+        groups.setdefault(str(race_key), []).append(index)
+    for indices in groups.values():
+        index_array = np.asarray(indices, dtype=np.int64)
+        values = log_win_odds[index_array]
+        order = np.argsort(values, kind="stable")
+        ordered_values = values[order]
+        ordered_ranks = np.empty(len(order), dtype=np.float64)
+        start = 0
+        while start < len(order):
+            stop = start + 1
+            while stop < len(order) and ordered_values[stop] == ordered_values[start]:
+                stop += 1
+            midrank = ((start + 1) + stop) / 2.0
+            ordered_ranks[start:stop] = midrank
+            start = stop
+        inverse_order = np.empty(len(order), dtype=np.int64)
+        inverse_order[order] = np.arange(len(order), dtype=np.int64)
+        ranks[index_array] = ordered_ranks[inverse_order]
+    return ranks
+
+
+def run_popularity_carrier_comparison(
+    dataset: ComparisonDataset,
+    input_audit: InputAudit,
+    *,
+    c_grid: Sequence[float] = DEFAULT_C_GRID,
+    bootstrap_repetitions: int = 2_000,
+    random_seed: int = 656,
+) -> PopularityCarrierComparisonResult:
+    years = dataset.years
+    train_mask = years == 2023
+    validation_mask = years == 2024
+    final_train_mask = np.isin(years, [2023, 2024])
+    holdout_mask = years == 2025
+    if (
+        min(
+            int(train_mask.sum()),
+            int(validation_mask.sum()),
+            int(holdout_mask.sum()),
+        )
+        == 0
+    ):
+        raise ValueError("2023 train, 2024 selection, and 2025 historical evaluation are required")
+
+    variant_fits: dict[str, _VariantFit] = {}
+    metrics: list[dict[str, Any]] = []
+    hyperparameter_rows: list[dict[str, Any]] = []
+    for variant in ALL_VARIANTS:
+        variant_dataset = market_variant_dataset(dataset, variant)
+        fit = _fit_market_variant(
+            variant_dataset,
+            variant=variant,
+            c_grid=c_grid,
+            train_mask=train_mask,
+            validation_mask=validation_mask,
+            final_train_mask=final_train_mask,
+            holdout_mask=holdout_mask,
+        )
+        variant_fits[variant] = fit
+        metrics.extend(fit.metrics)
+        hyperparameter_rows.extend(fit.hyperparameters)
+
+    selected_safe_variant = min(
+        SAFE_VARIANTS,
+        key=lambda name: (
+            _metric_value(metrics, "2024_selection", f"{name}_M1C", "log_loss"),
+            name,
+        ),
+    )
+
+    validation = dataset.subset(validation_mask)
+    holdout = dataset.subset(holdout_mask)
+    bootstrap_rows: list[dict[str, Any]] = []
+    for period_label, evaluation, probability_field in (
+        ("2024_selection", validation, "validation_constrained"),
+        ("2025_historical_evaluation", holdout, "holdout_constrained"),
+    ):
+        legacy_probabilities = getattr(
+            variant_fits[LEGACY_RESULT_POPULARITY],
+            probability_field,
+        )
+        for safe_variant in SAFE_VARIANTS:
+            bootstrap_rows.append(
+                race_bootstrap_log_loss_delta(
+                    period_label=period_label,
+                    baseline_name=f"{LEGACY_RESULT_POPULARITY}_M1C",
+                    candidate_name=f"{safe_variant}_M1C",
+                    targets=evaluation.targets,
+                    baseline_probabilities=legacy_probabilities,
+                    candidate_probabilities=getattr(variant_fits[safe_variant], probability_field),
+                    race_keys=evaluation.race_keys,
+                    repetitions=bootstrap_repetitions,
+                    random_seed=random_seed,
+                )
+            )
+        bootstrap_rows.append(
+            race_bootstrap_log_loss_delta(
+                period_label=period_label,
+                baseline_name=f"{NO_POPULARITY}_M1C",
+                candidate_name=f"{DECISION_TIME_WIN_RANK}_M1C",
+                targets=evaluation.targets,
+                baseline_probabilities=getattr(variant_fits[NO_POPULARITY], probability_field),
+                candidate_probabilities=getattr(
+                    variant_fits[DECISION_TIME_WIN_RANK],
+                    probability_field,
+                ),
+                race_keys=evaluation.race_keys,
+                repetitions=bootstrap_repetitions,
+                random_seed=random_seed,
+            )
+        )
+
+    rank_agreement_rows = _rank_agreement_rows(dataset)
+    selected_holdout_delta = _bootstrap_delta(
+        bootstrap_rows,
+        period_label="2025_historical_evaluation",
+        candidate_name=f"{selected_safe_variant}_M1C",
+        baseline_name=f"{LEGACY_RESULT_POPULARITY}_M1C",
+    )
+    selected_validation_delta = _bootstrap_delta(
+        bootstrap_rows,
+        period_label="2024_selection",
+        candidate_name=f"{selected_safe_variant}_M1C",
+        baseline_name=f"{LEGACY_RESULT_POPULARITY}_M1C",
+    )
+    holdout_ci_low = float(selected_holdout_delta["ci95_low"])
+    holdout_ci_high = float(selected_holdout_delta["ci95_high"])
+    if holdout_ci_high < 0.0:
+        empirical_verdict = "SELECTED_SAFE_CANDIDATE_IMPROVED_ON_2025_PAIRED_BOOTSTRAP"
+    elif holdout_ci_low > 0.0:
+        empirical_verdict = "SELECTED_SAFE_CANDIDATE_TRAILED_ON_2025_PAIRED_BOOTSTRAP"
+    else:
+        empirical_verdict = "SELECTED_SAFE_CANDIDATE_INDISTINGUISHABLE_ON_2025_PAIRED_BOOTSTRAP"
+    recommendation = (
+        "PREREGISTER_DECISION_TIME_WIN_RANK_AND_RERUN_PHASE651_TO_PHASE653"
+        if selected_safe_variant == DECISION_TIME_WIN_RANK
+        else "PREREGISTER_NO_POPULARITY_AND_RERUN_PHASE651_TO_PHASE653"
+    )
+    summary: dict[str, Any] = {
+        "analysis_version": "phase656_popularity_carrier_comparison_v1",
+        "final_verdict": FINAL_VERDICT,
+        "semantic_verdict": SEMANTIC_VERDICT,
+        "empirical_verdict": empirical_verdict,
+        "research_question": (
+            "which decision-time-safe replacement for result-side popularity should define "
+            "the prospective market baseline"
+        ),
+        "variants": {
+            LEGACY_RESULT_POPULARITY: (
+                "log win odds, log place-basis odds, and result-side SED popularity; "
+                "diagnostic comparator only"
+            ),
+            NO_POPULARITY: "log win odds and log place-basis odds",
+            DECISION_TIME_WIN_RANK: (
+                "log win odds, log place-basis odds, and per-race midrank derived only "
+                "from observed win odds"
+            ),
+        },
+        "selection_contract": {
+            "train": 2023,
+            "safe_candidate_selection": 2024,
+            "historical_evaluation_after_selection": 2025,
+            "selection_metric": "M1C constrained mean binary log loss",
+            "safe_candidates": list(SAFE_VARIANTS),
+            "legacy_result_popularity_eligible_for_selection": False,
+            "2025_claimed_fresh": False,
+        },
+        "selected_safe_variant": selected_safe_variant,
+        "selected_c_by_variant": {
+            variant: variant_fits[variant].selected_c for variant in ALL_VARIANTS
+        },
+        "selected_vs_legacy": {
+            "2024_point_log_loss_delta": selected_validation_delta["point_log_loss_delta"],
+            "2024_ci95_low": selected_validation_delta["ci95_low"],
+            "2024_ci95_high": selected_validation_delta["ci95_high"],
+            "2025_point_log_loss_delta": selected_holdout_delta["point_log_loss_delta"],
+            "2025_ci95_low": selected_holdout_delta["ci95_low"],
+            "2025_ci95_high": selected_holdout_delta["ci95_high"],
+        },
+        "input_audit": {
+            "joined_row_count": input_audit.joined_row_count,
+            "joined_rows_by_year": input_audit.joined_rows_by_year,
+            "target_mismatch_count_corrected_by_phase650h": (
+                input_audit.existing_market_target_mismatch_count
+            ),
+        },
+        "recommendation": recommendation,
+        "phase654_contract_changed": False,
+        "2026_data_used": False,
+        "roi_or_betting_used": False,
+    }
+    return PopularityCarrierComparisonResult(
+        summary=summary,
+        metrics=tuple(metrics),
+        bootstrap_rows=tuple(bootstrap_rows),
+        rank_agreement_rows=rank_agreement_rows,
+        hyperparameter_rows=tuple(hyperparameter_rows),
+    )
+
+
+def write_popularity_carrier_comparison(
+    result: PopularityCarrierComparisonResult,
+    output_dir: Path,
+) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _write_json(output_dir / "phase656_summary.json", result.summary)
+    _write_csv(output_dir / "phase656_market_metrics.csv", result.metrics)
+    _write_csv(output_dir / "phase656_bootstrap.csv", result.bootstrap_rows)
+    _write_csv(output_dir / "phase656_rank_agreement.csv", result.rank_agreement_rows)
+    _write_csv(output_dir / "phase656_hyperparameters.csv", result.hyperparameter_rows)
+    (output_dir / "phase656_findings.md").write_text(
+        _findings_markdown(result),
+        encoding="utf-8",
+    )
+
+
+def _fit_market_variant(
+    dataset: ComparisonDataset,
+    *,
+    variant: str,
+    c_grid: Sequence[float],
+    train_mask: NDArray[np.bool_],
+    validation_mask: NDArray[np.bool_],
+    final_train_mask: NDArray[np.bool_],
+    holdout_mask: NDArray[np.bool_],
+) -> _VariantFit:
+    train = dataset.subset(train_mask)
+    validation = dataset.subset(validation_mask)
+    final_train = dataset.subset(final_train_mask)
+    holdout = dataset.subset(holdout_mask)
+    if not c_grid:
+        raise ValueError("at least one logistic C value is required")
+
+    selection_transformer = NumericTransformer.fit(train.market_features)
+    train_values = selection_transformer.transform(train.market_features)
+    validation_values = selection_transformer.transform(validation.market_features)
+    hyperparameters: list[dict[str, Any]] = []
+    validation_predictions_by_c: dict[float, FloatArray] = {}
+    for c_value in c_grid:
+        model = fit_logistic_probability_model(train_values, train.targets, float(c_value))
+        probabilities = predict_positive_probability(model, validation_values)
+        validation_predictions_by_c[float(c_value)] = probabilities
+        hyperparameters.append(
+            {
+                "c": float(c_value),
+                "validation_log_loss": float(
+                    log_loss(validation.targets, probabilities, labels=[0, 1])
+                ),
+                "selected": False,
+            }
+        )
+    selected = min(
+        hyperparameters,
+        key=lambda row: (float(row["validation_log_loss"]), float(row["c"])),
+    )
+    selected["selected"] = True
+    selected_c = float(selected["c"])
+    validation_raw = validation_predictions_by_c[selected_c]
+    validation_constrained = constrain_probabilities_by_race(
+        validation_raw,
+        validation.race_keys,
+        validation.place_slots,
+    )
+
+    final_transformer = NumericTransformer.fit(final_train.market_features)
+    final_train_values = final_transformer.transform(final_train.market_features)
+    holdout_values = final_transformer.transform(holdout.market_features)
+    final_model = fit_logistic_probability_model(
+        final_train_values,
+        final_train.targets,
+        selected_c,
+    )
+    holdout_raw = predict_positive_probability(final_model, holdout_values)
+    holdout_constrained = constrain_probabilities_by_race(
+        holdout_raw,
+        holdout.race_keys,
+        holdout.place_slots,
+    )
+
+    for row in hyperparameters:
+        row["variant"] = variant
+    metrics = (
+        metric_row("2024_selection", f"{variant}_M1", validation, validation_raw),
+        metric_row(
+            "2024_selection",
+            f"{variant}_M1C",
+            validation,
+            validation_constrained,
+        ),
+        metric_row("2025_historical_evaluation", f"{variant}_M1", holdout, holdout_raw),
+        metric_row(
+            "2025_historical_evaluation",
+            f"{variant}_M1C",
+            holdout,
+            holdout_constrained,
+        ),
+    )
+    return _VariantFit(
+        selected_c=selected_c,
+        validation_raw=validation_raw,
+        validation_constrained=validation_constrained,
+        holdout_raw=holdout_raw,
+        holdout_constrained=holdout_constrained,
+        metrics=metrics,
+        hyperparameters=tuple(hyperparameters),
+    )
+
+
+def _rank_agreement_rows(dataset: ComparisonDataset) -> tuple[dict[str, Any], ...]:
+    derived = decision_time_win_midranks(dataset.market_features[:, 0], dataset.race_keys)
+    legacy = np.asarray(dataset.market_features[:, 2], dtype=np.float64)
+    rows: list[dict[str, Any]] = []
+    for label, mask in (
+        ("all", np.ones(len(legacy), dtype=np.bool_)),
+        *((str(year), dataset.years == year) for year in (2023, 2024, 2025)),
+    ):
+        difference = np.abs(legacy[mask] - derived[mask])
+        rows.append(
+            {
+                "period": label,
+                "row_count": int(mask.sum()),
+                "exact_match_rate": float(np.mean(difference == 0.0)),
+                "mean_absolute_rank_difference": float(np.mean(difference)),
+                "rank_correlation": _safe_correlation(legacy[mask], derived[mask]),
+            }
+        )
+    return tuple(rows)
+
+
+def _safe_correlation(left: FloatArray, right: FloatArray) -> float | None:
+    if len(left) < 2 or float(np.std(left)) == 0.0 or float(np.std(right)) == 0.0:
+        return None
+    return float(np.corrcoef(left, right)[0, 1])
+
+
+def _metric_value(
+    rows: Sequence[dict[str, Any]],
+    period_label: str,
+    model_name: str,
+    metric_name: str,
+) -> float:
+    matches = [
+        row
+        for row in rows
+        if row["period_label"] == period_label and row["model_name"] == model_name
+    ]
+    if len(matches) != 1:
+        raise ValueError(f"expected one metric row for {period_label}/{model_name}")
+    return float(matches[0][metric_name])
+
+
+def _bootstrap_delta(
+    rows: Sequence[dict[str, Any]],
+    *,
+    period_label: str,
+    candidate_name: str,
+    baseline_name: str,
+) -> dict[str, Any]:
+    matches = [
+        row
+        for row in rows
+        if row["period_label"] == period_label
+        and row["candidate_name"] == candidate_name
+        and row["baseline_name"] == baseline_name
+    ]
+    if len(matches) != 1:
+        raise ValueError(
+            f"expected one bootstrap row for {period_label}/{baseline_name}/{candidate_name}"
+        )
+    return matches[0]
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_csv(path: Path, rows: Sequence[dict[str, Any]]) -> None:
+    fieldnames = list(rows[0]) if rows else []
+    with path.open("w", encoding="utf-8", newline="") as file:
+        if not fieldnames:
+            return
+        writer = csv.DictWriter(file, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _findings_markdown(result: PopularityCarrierComparisonResult) -> str:
+    selected = result.summary["selected_safe_variant"]
+    delta = result.summary["selected_vs_legacy"]
+    return "\n".join(
+        [
+            "# Phase656 Popularity Carrier Comparison",
+            "",
+            "## Verdict",
+            "",
+            f"`{result.summary['final_verdict']}`",
+            "",
+            f"Selected safe candidate: `{selected}`.",
+            "",
+            "Result-side SED popularity remains ineligible for prospective use regardless of "
+            "its historical score.",
+            "",
+            "## Selected candidate versus legacy diagnostic",
+            "",
+            f"- 2024 constrained log-loss delta: {delta['2024_point_log_loss_delta']:.9f}",
+            f"- 2025 constrained log-loss delta: {delta['2025_point_log_loss_delta']:.9f}",
+            "",
+            "The safe candidate was selected on 2024 only. The 2025 result is historical "
+            "evaluation, not a fresh holdout claim.",
+            "",
+            "## Next step",
+            "",
+            f"`{result.summary['recommendation']}`",
+            "",
+            "No 2026 data, ROI, payout, threshold, stake, or betting rule was used.",
+            "",
+        ]
+    )

--- a/tests/test_popularity_carrier_comparison.py
+++ b/tests/test_popularity_carrier_comparison.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import numpy as np
+
+from horse_bet_lab.research.historical_ability_models import (
+    HISTORY_NUMERIC_FEATURE_COLUMNS,
+    ComparisonDataset,
+    InputAudit,
+)
+from horse_bet_lab.research.popularity_carrier_comparison import (
+    DECISION_TIME_WIN_RANK,
+    FINAL_VERDICT,
+    NO_POPULARITY,
+    decision_time_win_midranks,
+    market_variant_dataset,
+    run_popularity_carrier_comparison,
+    write_popularity_carrier_comparison,
+)
+
+
+def test_decision_time_rank_uses_midrank_for_tied_visible_odds() -> None:
+    values = np.asarray([1.0, 1.0, 2.0, 0.5, 1.5], dtype=np.float64)
+    race_keys = np.asarray(["A", "A", "A", "B", "B"], dtype=object)
+
+    ranks = decision_time_win_midranks(values, race_keys)
+
+    assert ranks.tolist() == [1.5, 1.5, 3.0, 1.0, 2.0]
+
+
+def test_market_variants_remove_or_rederive_legacy_popularity() -> None:
+    dataset, _ = _synthetic_inputs()
+
+    no_popularity = market_variant_dataset(dataset, NO_POPULARITY)
+    decision_time_rank = market_variant_dataset(dataset, DECISION_TIME_WIN_RANK)
+
+    assert no_popularity.market_features.shape[1] == 2
+    assert decision_time_rank.market_features.shape[1] == 3
+    assert not np.array_equal(
+        decision_time_rank.market_features[:, 2],
+        dataset.market_features[:, 2],
+    )
+
+
+def test_comparison_selects_only_a_safe_candidate_and_writes_reports(tmp_path: Path) -> None:
+    dataset, audit = _synthetic_inputs()
+
+    result = run_popularity_carrier_comparison(
+        dataset,
+        audit,
+        c_grid=(0.1, 1.0),
+        bootstrap_repetitions=20,
+    )
+    output_dir = tmp_path / "reports"
+    write_popularity_carrier_comparison(result, output_dir)
+
+    assert result.summary["final_verdict"] == FINAL_VERDICT
+    assert result.summary["selected_safe_variant"] in {
+        NO_POPULARITY,
+        DECISION_TIME_WIN_RANK,
+    }
+    assert result.summary["2026_data_used"] is False
+    assert result.summary["roi_or_betting_used"] is False
+    assert result.summary["phase654_contract_changed"] is False
+    assert {path.name for path in output_dir.iterdir()} == {
+        "phase656_summary.json",
+        "phase656_market_metrics.csv",
+        "phase656_bootstrap.csv",
+        "phase656_rank_agreement.csv",
+        "phase656_hyperparameters.csv",
+        "phase656_findings.md",
+    }
+
+
+def _synthetic_inputs() -> tuple[ComparisonDataset, InputAudit]:
+    race_dates: list[date] = []
+    race_keys: list[str] = []
+    horse_numbers: list[int] = []
+    targets: list[int] = []
+    market_features: list[list[float]] = []
+    for year in (2023, 2024, 2025):
+        for race_index in range(5):
+            race_key = f"{year}-R{race_index}"
+            for horse_number in range(1, 9):
+                race_dates.append(date(year, 1, race_index + 1))
+                race_keys.append(race_key)
+                horse_numbers.append(horse_number)
+                targets.append(int(horse_number <= 3))
+                win_odds = 1.2 + horse_number + (race_index * 0.03)
+                place_odds = 1.0 + (horse_number * 0.35)
+                legacy_popularity = 9 - horse_number
+                market_features.append(
+                    [
+                        float(np.log1p(win_odds)),
+                        float(np.log1p(place_odds)),
+                        float(legacy_popularity),
+                    ]
+                )
+    row_count = len(targets)
+    dataset = ComparisonDataset(
+        race_dates=tuple(race_dates),
+        race_keys=np.asarray(race_keys, dtype=object),
+        horse_numbers=np.asarray(horse_numbers, dtype=np.int64),
+        targets=np.asarray(targets, dtype=np.int64),
+        market_targets=np.asarray(targets, dtype=np.int64),
+        market_features=np.asarray(market_features, dtype=np.float64),
+        history_numeric_features=np.zeros(
+            (row_count, len(HISTORY_NUMERIC_FEATURE_COLUMNS)),
+            dtype=np.float64,
+        ),
+        venue_codes=np.asarray(["01"] * row_count, dtype=object),
+        active_field_sizes=np.asarray([8] * row_count, dtype=np.int64),
+        place_slots=np.asarray([3] * row_count, dtype=np.int64),
+    )
+    audit = InputAudit(
+        source_verdict="HISTORICAL_ABILITY_SOURCE_BRIDGE_READY",
+        history_row_count=row_count,
+        market_row_count=row_count,
+        joined_row_count=row_count,
+        missing_history_row_count=0,
+        missing_history_race_count=0,
+        partially_joined_race_count=0,
+        fully_missing_unsupported_race_count=0,
+        duplicate_history_identity_count=0,
+        duplicate_market_identity_count=0,
+        existing_market_target_mismatch_count=0,
+        mismatch_direction_counts={},
+        mismatch_by_active_field_size={},
+        joined_rows_by_year={"2023": 40, "2024": 40, "2025": 40},
+    )
+    return dataset, audit


### PR DESCRIPTION
## What changed

- add Phase656 comparison of three market-feature contracts:
  - legacy result-side SED popularity
  - no popularity
  - decision-time win-odds midrank
- reuse the Phase650H corrected place labels and Phase651 logistic/race-constraint machinery
- select only between the two decision-time-safe candidates on 2024
- report 2025 as historical evaluation, not a fresh holdout
- emit metrics, race-level paired bootstrap, rank-agreement, hyperparameter, summary, and findings artifacts

## Why

Phase655 found that the frozen Phase651 market baseline uses a popularity carrier that cannot substantiate the prospective decision-time claim. This comparison determines the safe replacement before changing the preregistered Phase654 contract.

## Result

Selected safe candidate: `no_popularity`.

For the constrained market model versus the legacy result-side-popularity comparator:

- 2024 Log Loss delta: `-0.000029077` with 95% CI entirely below zero
- 2025 Log Loss delta: `+0.000002650` with 95% CI crossing zero

The decision-time win-rank variant was worse than no-popularity in both 2024 and 2025. The 2025 paired bootstrap cannot distinguish no-popularity from the legacy comparator.

Recommended next gate:

`PREREGISTER_NO_POPULARITY_AND_RERUN_PHASE651_TO_PHASE653`

## Boundaries

- no 2026 data used
- no Phase654 contract change
- no ROI, payout, threshold, stake, selection, or BET logic
- generated artifacts remain uncommitted

## Validation

- 27 relevant tests passed
- Ruff check passed
- Ruff format check passed
- strict Mypy passed
- compileall passed
- Phase650H rebuilt from 2019-2025 raw history with zero strict-prior violations
- 141,519 historical comparison rows joined
- summary JSON validated
