### PR TITLE
Phase657: rebase probability research without popularity

### DIFF
--- a/docs/phase657_no_popularity_rebase.md
+++ b/docs/phase657_no_popularity_rebase.md
@@ -1,0 +1,51 @@
+# Phase657 No-Popularity Rebase
+
+## Purpose
+
+Phase656 selected `no_popularity` as the decision-time-safe market contract. Phase657 reruns the
+historical Phase651-653 probability research before any preregistration is amended.
+
+The market model uses only:
+
+- log win odds;
+- log place-basis odds.
+
+No 2026 row is read. The 2025 period remains reused historical confirmation, not a fresh holdout.
+
+## Reused machinery
+
+- Phase650H corrected place-slot labels and strictly-prior history surface;
+- Phase651 chronological regularization selection and race probability constraint;
+- Phase652 race-group cross-fitting, ablations, and paired bootstrap;
+- Phase653 small-field decomposition and slot-2-only diagnostic.
+
+Phase651 now records the supplied market feature names rather than hard-coding popularity in its
+summary. Phase652 omits popularity subgroup slices when the market matrix has no popularity column.
+Phase653 leaves the descriptive mean-popularity field blank in the same case. Model formulas are
+unchanged.
+
+## Gate
+
+The historical conclusions are considered reproduced when:
+
+- Phase651 still supports incremental strictly-prior history signal; and
+- Phase652 does not change to `HISTORY_SIGNAL_CROSSFIT_NOT_CONFIRMED`.
+
+Phase652 may remain diagnostic-only because the known small-field pocket is the subject of
+Phase653, not a reason to restore an invalid result-side market feature.
+
+## Boundary
+
+This phase does not amend Phase654. It produces the evidence required for that amendment. It does
+not inspect 2026 data or use ROI, payouts, thresholds, stakes, selections, or BET logic.
+
+## Execution
+
+```bash
+PYTHONPATH=src .venv/bin/python scripts/phase657_no_popularity_rebase.py \
+  --history-surface /absolute/path/phase650h_history_surface.csv \
+  --source-summary /absolute/path/phase650h_source_summary.json \
+  --market-dataset /absolute/path/dual_market_logreg/dataset.parquet
+```
+
+Generated reports remain under `data/artifacts/` and are not committed.

--- a/scripts/phase657_no_popularity_rebase.py
+++ b/scripts/phase657_no_popularity_rebase.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from horse_bet_lab.research.historical_ability_models import load_comparison_dataset
+from horse_bet_lab.research.no_popularity_rebase import (
+    run_no_popularity_rebase,
+    write_no_popularity_rebase,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Rerun Phase651-653 with the selected no-popularity market contract.",
+    )
+    parser.add_argument("--history-surface", type=Path, required=True)
+    parser.add_argument("--source-summary", type=Path, required=True)
+    parser.add_argument("--market-dataset", type=Path, required=True)
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("data/artifacts/phase657_no_popularity_rebase"),
+    )
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    dataset, input_audit = load_comparison_dataset(
+        history_surface_path=args.history_surface,
+        source_summary_path=args.source_summary,
+        market_dataset_path=args.market_dataset,
+    )
+    result = run_no_popularity_rebase(dataset, input_audit)
+    write_no_popularity_rebase(result, args.output_dir)
+    print(json.dumps(result.summary, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/horse_bet_lab/research/historical_ability_models.py
+++ b/src/horse_bet_lab/research/historical_ability_models.py
@@ -381,10 +381,16 @@ def run_model_comparison(
     dataset: ComparisonDataset,
     input_audit: InputAudit,
     *,
+    market_feature_names: Sequence[str] = MARKET_FEATURE_COLUMNS,
     c_grid: Sequence[float] = DEFAULT_C_GRID,
     bootstrap_repetitions: int = 2_000,
     random_seed: int = 651,
 ) -> ComparisonResult:
+    if len(market_feature_names) != dataset.market_features.shape[1]:
+        raise ValueError(
+            "market feature names must match the comparison dataset width: "
+            f"names={len(market_feature_names)}, width={dataset.market_features.shape[1]}"
+        )
     years = dataset.years
     train = dataset.subset(years == 2023)
     validation = dataset.subset(years == 2024)
@@ -540,7 +546,9 @@ def run_model_comparison(
         },
         "model_contract": {
             "M0_race_prior": "place slots / active field size",
-            "M1_market": "logistic regression on win odds, place basis odds, popularity",
+            "M1_market": (
+                "logistic regression on " + ", ".join(str(value) for value in market_feature_names)
+            ),
             "M1C_race_constrained_market": (
                 "M1 with per-race probability sum constrained to place slots"
             ),
@@ -552,6 +560,7 @@ def run_model_comparison(
             ),
         },
         "selected_c": selected_c,
+        "market_feature_names": list(market_feature_names),
         "bootstrap_repetitions": bootstrap_repetitions,
         "verdict_evidence": verdict_evidence,
         "roi_or_betting_used_for_selection": False,

--- a/src/horse_bet_lab/research/historical_signal_robustness.py
+++ b/src/horse_bet_lab/research/historical_signal_robustness.py
@@ -465,6 +465,7 @@ def run_signal_robustness(
             "2025": "reused confirmation only; not a fresh holdout",
         },
         "feature_groups": FEATURE_GROUPS,
+        "market_popularity_subgroups_included": dataset.market_features.shape[1] >= 3,
         "feature_ablation_used_for_selection": False,
         "roi_or_betting_used": False,
         "operational_recommendation": RESEARCH_ONLY,
@@ -627,9 +628,8 @@ def _subgroup_masks(
 ) -> tuple[tuple[str, str, NDArray[np.bool_]], ...]:
     prior_index = HISTORY_NUMERIC_FEATURE_COLUMNS.index("prior_start_count")
     prior_starts = dataset.history_numeric_features[:, prior_index]
-    popularity = dataset.market_features[:, 2]
     months = np.asarray([value.month for value in dataset.race_dates], dtype=np.int64)
-    return (
+    masks: list[tuple[str, str, NDArray[np.bool_]]] = [
         ("prior_start_count", "0", prior_starts == 0),
         ("prior_start_count", "1-2", (prior_starts >= 1) & (prior_starts <= 2)),
         ("prior_start_count", "3-4", (prior_starts >= 3) & (prior_starts <= 4)),
@@ -641,12 +641,17 @@ def _subgroup_masks(
             (dataset.active_field_sizes >= 8) & (dataset.active_field_sizes <= 12),
         ),
         ("active_field_size", "13+", dataset.active_field_sizes >= 13),
-        ("market_popularity", "1-3", popularity <= 3),
-        ("market_popularity", "4-8", (popularity >= 4) & (popularity <= 8)),
-        ("market_popularity", "9+", popularity >= 9),
         ("half_year", "H1", months <= 6),
         ("half_year", "H2", months >= 7),
-    )
+    ]
+    if dataset.market_features.shape[1] >= 3:
+        popularity = dataset.market_features[:, 2]
+        masks[9:9] = [
+            ("market_popularity", "1-3", popularity <= 3),
+            ("market_popularity", "4-8", (popularity >= 4) & (popularity <= 8)),
+            ("market_popularity", "9+", popularity >= 9),
+        ]
+    return tuple(masks)
 
 
 def _robustness_verdict(

--- a/src/horse_bet_lab/research/no_popularity_rebase.py
+++ b/src/horse_bet_lab/research/no_popularity_rebase.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from horse_bet_lab.research.historical_ability_models import (
+    SIGNAL_SUPPORTED,
+    ComparisonDataset,
+    ComparisonResult,
+    InputAudit,
+    run_model_comparison,
+    write_comparison_result,
+)
+from horse_bet_lab.research.historical_signal_robustness import (
+    ROBUSTNESS_DIAGNOSTIC_ONLY,
+    ROBUSTNESS_NOT_CONFIRMED,
+    RobustnessResult,
+    run_signal_robustness,
+    write_robustness_result,
+)
+from horse_bet_lab.research.popularity_carrier_comparison import (
+    NO_POPULARITY,
+    market_variant_dataset,
+)
+from horse_bet_lab.research.small_field_failure_audit import (
+    SmallFieldAuditResult,
+    run_small_field_failure_audit,
+    write_small_field_audit,
+)
+
+REBASE_REPRODUCED = "NO_POPULARITY_REBASE_HISTORICAL_CONCLUSIONS_REPRODUCED"
+REBASE_CHANGED = "NO_POPULARITY_REBASE_HISTORICAL_CONCLUSION_CHANGED"
+
+
+@dataclass(frozen=True)
+class NoPopularityRebaseResult:
+    summary: dict[str, Any]
+    phase651: ComparisonResult
+    phase652: RobustnessResult
+    phase653: SmallFieldAuditResult
+
+
+def run_no_popularity_rebase(
+    dataset: ComparisonDataset,
+    input_audit: InputAudit,
+    *,
+    phase651_bootstrap_repetitions: int = 2_000,
+    phase652_bootstrap_repetitions: int = 2_000,
+    phase652_subgroup_bootstrap_repetitions: int = 500,
+    phase653_bootstrap_repetitions: int = 1_000,
+    phase653_minimum_bootstrap_races: int = 30,
+) -> NoPopularityRebaseResult:
+    safe_dataset = market_variant_dataset(dataset, NO_POPULARITY)
+    phase651 = run_model_comparison(
+        safe_dataset,
+        input_audit,
+        market_feature_names=("win_odds", "place_basis_odds"),
+        bootstrap_repetitions=phase651_bootstrap_repetitions,
+    )
+    selected_c = phase651.summary["selected_c"]
+    market_c = float(selected_c["M1_market"])
+    offset_c = float(selected_c["M4_market_offset_history"])
+    phase652 = run_signal_robustness(
+        safe_dataset,
+        market_c=market_c,
+        offset_c=offset_c,
+        bootstrap_repetitions=phase652_bootstrap_repetitions,
+        subgroup_bootstrap_repetitions=phase652_subgroup_bootstrap_repetitions,
+    )
+    phase653 = run_small_field_failure_audit(
+        safe_dataset,
+        market_c=market_c,
+        offset_c=offset_c,
+        bootstrap_repetitions=phase653_bootstrap_repetitions,
+        minimum_bootstrap_races=phase653_minimum_bootstrap_races,
+    )
+    summary = build_no_popularity_rebase_summary(
+        phase651.summary,
+        phase652.summary,
+        phase653.summary,
+    )
+    return NoPopularityRebaseResult(
+        summary=summary,
+        phase651=phase651,
+        phase652=phase652,
+        phase653=phase653,
+    )
+
+
+def build_no_popularity_rebase_summary(
+    phase651_summary: dict[str, Any],
+    phase652_summary: dict[str, Any],
+    phase653_summary: dict[str, Any],
+) -> dict[str, Any]:
+    phase651_supported = phase651_summary["final_verdict"] == SIGNAL_SUPPORTED
+    phase652_not_failed = phase652_summary["final_verdict"] != ROBUSTNESS_NOT_CONFIRMED
+    supported_small_field_harm = phase653_summary["supported_small_field_harm"]
+    stable_slot2_pairs = phase653_summary["stable_slot2_specific_recovery_pairs"]
+    small_field_harm_reproduced = bool(supported_small_field_harm)
+    slot2_recovery_signal_reproduced = bool(stable_slot2_pairs)
+    conclusions_reproduced = (
+        phase651_supported
+        and phase652_not_failed
+        and small_field_harm_reproduced
+        and slot2_recovery_signal_reproduced
+    )
+    return {
+        "analysis_version": "phase657_no_popularity_rebase_v1",
+        "final_verdict": REBASE_REPRODUCED if conclusions_reproduced else REBASE_CHANGED,
+        "market_feature_contract": ["win_odds", "place_basis_odds"],
+        "phase651_final_verdict": phase651_summary["final_verdict"],
+        "phase652_final_verdict": phase652_summary["final_verdict"],
+        "phase652_remains_diagnostic_only": (
+            phase652_summary["final_verdict"] == ROBUSTNESS_DIAGNOSTIC_ONLY
+        ),
+        "phase653_final_verdict": phase653_summary["final_verdict"],
+        "phase653_supported_small_field_harm_count": len(supported_small_field_harm),
+        "phase653_small_field_harm_reproduced": small_field_harm_reproduced,
+        "phase653_stable_slot2_recovery_pairs": stable_slot2_pairs,
+        "phase653_slot2_recovery_signal_reproduced": slot2_recovery_signal_reproduced,
+        "recommendation": (
+            "AMEND_PREREGISTRATION_TO_NO_POPULARITY_BEFORE_FORWARD_MODEL_EVALUATION"
+            if conclusions_reproduced
+            else "DO_NOT_AMEND_PREREGISTRATION_UNTIL_CHANGED_CONCLUSION_IS_REVIEWED"
+        ),
+        "2026_data_used": False,
+        "2025_claimed_fresh": False,
+        "roi_or_betting_used": False,
+    }
+
+
+def write_no_popularity_rebase(
+    result: NoPopularityRebaseResult,
+    output_dir: Path,
+) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_comparison_result(result.phase651, output_dir / "phase651")
+    write_robustness_result(result.phase652, output_dir / "phase652")
+    write_small_field_audit(result.phase653, output_dir / "phase653")
+    (output_dir / "phase657_summary.json").write_text(
+        json.dumps(result.summary, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "phase657_findings.md").write_text(
+        _findings_markdown(result),
+        encoding="utf-8",
+    )
+
+
+def _findings_markdown(result: NoPopularityRebaseResult) -> str:
+    return "\n".join(
+        [
+            "# Phase657 No-Popularity Rebase",
+            "",
+            "## Verdict",
+            "",
+            f"`{result.summary['final_verdict']}`",
+            "",
+            "## Reproduced phase verdicts",
+            "",
+            f"- Phase651: `{result.summary['phase651_final_verdict']}`",
+            f"- Phase652: `{result.summary['phase652_final_verdict']}`",
+            f"- Phase653: `{result.summary['phase653_final_verdict']}`",
+            "",
+            "The rerun uses only log win odds and log place-basis odds for the market model. "
+            "Popularity-dependent subgroup descriptions are omitted.",
+            "",
+            "## Next gate",
+            "",
+            f"`{result.summary['recommendation']}`",
+            "",
+            "No 2026 data, ROI, payout, threshold, stake, or betting rule was used.",
+            "",
+        ]
+    )

--- a/src/horse_bet_lab/research/small_field_failure_audit.py
+++ b/src/horse_bet_lab/research/small_field_failure_audit.py
@@ -531,7 +531,11 @@ def _history_profile_row(
         "zero_prior_start_rate": float(np.mean(prior_starts == 0)),
         "missing_last1_rate": float(np.mean(~np.isfinite(last1))),
         "mean_days_since_last_start": (float(finite_days.mean()) if len(finite_days) else ""),
-        "mean_market_popularity": float(dataset.market_features[mask, 2].mean()),
+        "mean_market_popularity": (
+            float(dataset.market_features[mask, 2].mean())
+            if dataset.market_features.shape[1] >= 3
+            else ""
+        ),
     }
 
 

--- a/tests/test_historical_signal_robustness.py
+++ b/tests/test_historical_signal_robustness.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import date, timedelta
 from pathlib import Path
 
@@ -98,6 +99,22 @@ def test_robustness_writer_emits_only_diagnostic_outputs(tmp_path: Path) -> None
         "phase652_findings.md",
     }
     assert not any("roi" in path.name or "bet" in path.name for path in output_dir.iterdir())
+
+
+def test_robustness_omits_popularity_subgroups_for_two_column_market() -> None:
+    dataset = _synthetic_dataset(years=(2023, 2024, 2025), races_per_year=10)
+    dataset = replace(dataset, market_features=dataset.market_features[:, :2])
+
+    result = run_signal_robustness(
+        dataset,
+        crossfit_folds=2,
+        bootstrap_repetitions=20,
+        subgroup_bootstrap_repetitions=10,
+        minimum_subgroup_rows=10,
+    )
+
+    assert result.summary["market_popularity_subgroups_included"] is False
+    assert not any(row["dimension"] == "market_popularity" for row in result.subgroup_rows)
 
 
 def _synthetic_dataset(

--- a/tests/test_no_popularity_rebase.py
+++ b/tests/test_no_popularity_rebase.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from horse_bet_lab.research.historical_ability_models import SIGNAL_SUPPORTED
+from horse_bet_lab.research.historical_signal_robustness import ROBUSTNESS_DIAGNOSTIC_ONLY
+from horse_bet_lab.research.no_popularity_rebase import (
+    REBASE_CHANGED,
+    REBASE_REPRODUCED,
+    build_no_popularity_rebase_summary,
+)
+
+
+def test_rebase_summary_allows_diagnostic_phase652_when_signal_is_reproduced() -> None:
+    summary = build_no_popularity_rebase_summary(
+        {"final_verdict": SIGNAL_SUPPORTED},
+        {"final_verdict": ROBUSTNESS_DIAGNOSTIC_ONLY},
+        {
+            "final_verdict": "SMALL_FIELD_FAILURE_CAUSE_AUDITED_DIAGNOSTIC_ONLY",
+            "supported_small_field_harm": [{"group": "5-7"}],
+            "stable_slot2_specific_recovery_pairs": [
+                {"feature_scope": "full", "model_kind": "offset"}
+            ],
+        },
+    )
+
+    assert summary["final_verdict"] == REBASE_REPRODUCED
+    assert summary["recommendation"].startswith("AMEND_PREREGISTRATION")
+    assert summary["2026_data_used"] is False
+    assert summary["roi_or_betting_used"] is False
+
+
+def test_rebase_summary_stops_when_phase651_signal_changes() -> None:
+    summary = build_no_popularity_rebase_summary(
+        {"final_verdict": "HISTORICAL_ABILITY_SIGNAL_NOT_SUPPORTED"},
+        {"final_verdict": ROBUSTNESS_DIAGNOSTIC_ONLY},
+        {
+            "final_verdict": "SMALL_FIELD_FAILURE_CAUSE_AUDITED_DIAGNOSTIC_ONLY",
+            "supported_small_field_harm": [],
+            "stable_slot2_specific_recovery_pairs": [],
+        },
+    )
+
+    assert summary["final_verdict"] == REBASE_CHANGED
+    assert summary["recommendation"].startswith("DO_NOT_AMEND")

--- a/tests/test_small_field_failure_audit.py
+++ b/tests/test_small_field_failure_audit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import date, timedelta
 from pathlib import Path
 
@@ -101,6 +102,23 @@ def test_writer_emits_only_diagnostic_outputs(tmp_path: Path) -> None:
         for path in output_dir.iterdir()
         for token in ("roi", "bet", "candidate", "exclusion")
     )
+
+
+def test_small_field_profile_allows_two_column_market() -> None:
+    dataset = _synthetic_mixed_field_dataset(races_per_year=6)
+    dataset = replace(dataset, market_features=dataset.market_features[:, :2])
+
+    result = run_small_field_failure_audit(
+        dataset,
+        crossfit_folds=2,
+        bootstrap_repetitions=10,
+        minimum_bootstrap_races=2,
+    )
+
+    assert result.history_profile_rows
+    populated_rows = [row for row in result.history_profile_rows if int(row["row_count"]) > 0]
+    assert populated_rows
+    assert all(row["mean_market_popularity"] == "" for row in populated_rows)
 
 
 def _synthetic_mixed_field_dataset(


### PR DESCRIPTION
## What changed

- rerun Phase651-653 with the Phase656-selected safe market contract:
  - `win_odds`
  - `place_basis_odds`
- allow Phase651 to record an explicit market feature sequence
- allow Phase652 to omit popularity subgroup slices when popularity is absent
- allow Phase653 descriptive profiles to leave popularity blank when absent
- add a Phase657 orchestration/report layer

## Result

`NO_POPULARITY_REBASE_HISTORICAL_CONCLUSIONS_REPRODUCED`

- Phase651: `HISTORICAL_ABILITY_INCREMENTAL_SIGNAL_SUPPORTED`
- Phase652: `HISTORY_SIGNAL_CROSSFIT_DIAGNOSTIC_ONLY`
- Phase653: `SMALL_FIELD_FAILURE_CAUSE_AUDITED_DIAGNOSTIC_ONLY`
- supported small-field harm rows: 5
- stable slot-2 recovery signal: `full / offset`

The probability formulas, chronological split, race constraint, cross-fitting, bootstrap, and small-field diagnostics are unchanged. Only the invalid result-side popularity feature and its descriptive slices are removed.

## Recommendation

`AMEND_PREREGISTRATION_TO_NO_POPULARITY_BEFORE_FORWARD_MODEL_EVALUATION`

## Boundaries

- no 2026 data used
- 2025 is not claimed fresh
- no Phase654 amendment in this PR
- no ROI, payout, threshold, stake, selection, or BET logic
- generated artifacts uncommitted

## Validation

- 31 relevant tests passed
- Ruff check and format check passed
- strict Mypy passed for four research modules
- compileall passed
- full Phase651-653 historical rerun completed
- summary JSON validated
