### PR TITLE
Phase658: amend forward preregistration without popularity

### DIFF
--- a/configs/phase658_2026_forward_preregistered_validation.json
+++ b/configs/phase658_2026_forward_preregistered_validation.json
@@ -1,0 +1,218 @@
+{
+  "contract_version": 2,
+  "phase": "Phase658",
+  "research_question": "Does strictly-prior horse history improve place-probability estimation beyond the decision-time market on a prospectively collected 2026 forward period, and does slot-2-specific training repair the previously unstable small-field pocket?",
+  "amendment": {
+    "supersedes_phase": "Phase654",
+    "superseded_contract_path": "configs/phase654_2026_forward_preregistered_validation.json",
+    "superseded_contract_sha256": "90070eca4bf576a2752dfdc4ba18d91367236664bfa17b782e88586653089297",
+    "reason": "Phase655 found that historical popularity came from result-side SED and was not prospectively reproducible. Phase656 selected a no-popularity decision-time market contract, and Phase657 reproduced the historical Phase651-653 conclusions under that contract before the forward window began.",
+    "evidence": {
+      "phase655_verdict": "FORWARD_COLLECTION_READINESS_BLOCKED",
+      "phase655_merge_commit": "4b05bb8c2c883baedf7953c893cab44e25e57be2",
+      "phase656_verdict": "DECISION_TIME_MARKET_FEATURE_CANDIDATE_SELECTED",
+      "phase656_selected_safe_variant": "no_popularity",
+      "phase656_merge_commit": "9ed80d519abf049e750d3b58c5e6ae098043e2e3",
+      "phase657_verdict": "NO_POPULARITY_REBASE_HISTORICAL_CONCLUSIONS_REPRODUCED",
+      "phase657_recommendation": "AMEND_PREREGISTRATION_TO_NO_POPULARITY_BEFORE_FORWARD_MODEL_EVALUATION",
+      "phase657_merge_commit": "e82525a8af0440be459982b0d46bba8378fe32c0",
+      "2026_data_used": false,
+      "2025_claimed_fresh": false,
+      "roi_or_betting_used": false
+    }
+  },
+  "freshness": {
+    "claim": "The evaluation window begins after registration and no aggregate Phase650H, Phase652, or Phase653 model evaluation on that window may be inspected before the evaluation unlock date.",
+    "does_not_claim": "This contract makes no freshness claim about 2026 races before the prospective evaluation window.",
+    "source_audit_allowed_only_after_contract_merge": true,
+    "model_or_threshold_change_after_source_audit": "forbidden"
+  },
+  "periods": {
+    "training_start": "2023-01-01",
+    "training_end": "2025-12-31",
+    "evaluation_start": "2026-07-20",
+    "evaluation_end": "2026-12-31",
+    "evaluation_unlock_date": "2027-01-01",
+    "evaluation_label": "2026_forward_fresh_confirmation"
+  },
+  "data_contract": {
+    "history_surface": "Phase650H strictly-prior historical ability surface",
+    "market_surface": "Phase657 no-popularity decision-time market surface",
+    "target": "Phase651 place-slot-aware is_place",
+    "identity": [
+      "race_key",
+      "horse_number"
+    ],
+    "complete_races_only": true,
+    "reject_duplicate_identity": true,
+    "reject_partial_history_join": true,
+    "reject_target_or_place_slot_mismatch": true,
+    "place_slot_rule": {
+      "field_size_5_to_7": 2,
+      "field_size_8_or_more": 3,
+      "field_size_4_or_less": "unsupported"
+    }
+  },
+  "market_contract": {
+    "contract_id": "phase658_no_popularity_decision_time_market_v1",
+    "feature_order": [
+      "win_odds",
+      "place_basis_odds"
+    ],
+    "feature_transforms": {
+      "win_odds": "log1p",
+      "place_basis_odds": "log1p"
+    },
+    "numeric_preprocessing": "training-fit median imputation, missing indicators, mean centering, and population-standard-deviation scaling",
+    "excluded_features": [
+      "popularity"
+    ],
+    "excluded_feature_reason": "the historical popularity field is carried by result-side SED and is not a confirmed decision-time input",
+    "applies_to": [
+      "M1C_race_constrained_market",
+      "M5_full_pooled",
+      "M5_history_only_pooled",
+      "M5_full_slot2_only",
+      "M5_history_only_slot2_only"
+    ]
+  },
+  "fixed_models": {
+    "M1C_race_constrained_market": {
+      "feature_scope": "market_only",
+      "training_scope": "all_supported_place_slots",
+      "race_probability_sum_constraint": true
+    },
+    "M5_full_pooled": {
+      "feature_scope": "full_phase652_history_plus_current_context",
+      "training_scope": "all_supported_place_slots",
+      "race_probability_sum_constraint": true
+    },
+    "M5_history_only_pooled": {
+      "feature_scope": "phase652_without_current_context",
+      "training_scope": "all_supported_place_slots",
+      "race_probability_sum_constraint": true
+    },
+    "M5_full_slot2_only": {
+      "feature_scope": "full_phase652_history_plus_current_context",
+      "training_scope": "place_slots_2_only",
+      "race_probability_sum_constraint": true
+    },
+    "M5_history_only_slot2_only": {
+      "feature_scope": "phase652_without_current_context",
+      "training_scope": "place_slots_2_only",
+      "race_probability_sum_constraint": true
+    }
+  },
+  "comparisons": [
+    {
+      "id": "overall_history_only_vs_market",
+      "role": "primary_overall_signal",
+      "subset": "all_complete_supported_races",
+      "baseline": "M1C_race_constrained_market",
+      "candidate": "M5_history_only_pooled"
+    },
+    {
+      "id": "slot2_full_specific_vs_pooled",
+      "role": "primary_slot2_recovery",
+      "subset": "place_slots_2_only",
+      "baseline": "M5_full_pooled",
+      "candidate": "M5_full_slot2_only"
+    },
+    {
+      "id": "slot2_full_specific_vs_market",
+      "role": "primary_slot2_recovery",
+      "subset": "place_slots_2_only",
+      "baseline": "M1C_race_constrained_market",
+      "candidate": "M5_full_slot2_only"
+    },
+    {
+      "id": "overall_full_vs_market",
+      "role": "supporting",
+      "subset": "all_complete_supported_races",
+      "baseline": "M1C_race_constrained_market",
+      "candidate": "M5_full_pooled"
+    },
+    {
+      "id": "slot2_history_only_specific_vs_pooled",
+      "role": "supporting",
+      "subset": "place_slots_2_only",
+      "baseline": "M5_history_only_pooled",
+      "candidate": "M5_history_only_slot2_only"
+    },
+    {
+      "id": "slot2_history_only_specific_vs_market",
+      "role": "supporting",
+      "subset": "place_slots_2_only",
+      "baseline": "M1C_race_constrained_market",
+      "candidate": "M5_history_only_slot2_only"
+    }
+  ],
+  "analysis": {
+    "primary_metric": "mean_binary_log_loss",
+    "paired_unit": "race_key",
+    "bootstrap_repetitions": 2000,
+    "bootstrap_seed": 654,
+    "confidence_level": 0.95,
+    "market_logistic_c": 1.0,
+    "offset_logistic_c": 1.0,
+    "crossfit_folds": 5,
+    "crossfit_group": "race_key",
+    "crossfit_stratified": true,
+    "crossfit_seed": 652,
+    "minimum_complete_races_overall": 500,
+    "minimum_complete_races_place_slots_2": 50,
+    "minimum_rows_place_slots_2": 300,
+    "comparison_success_rule": "candidate_minus_baseline_point_delta_below_zero_and_ci95_high_below_zero",
+    "overall_signal_confirmation": [
+      "overall_history_only_vs_market"
+    ],
+    "slot2_recovery_confirmation": [
+      "slot2_full_specific_vs_pooled",
+      "slot2_full_specific_vs_market"
+    ],
+    "selection_metrics": [
+      "mean_binary_log_loss",
+      "paired_race_bootstrap_log_loss_delta"
+    ],
+    "supporting_metrics": [
+      "brier_score",
+      "calibration_intercept",
+      "calibration_slope",
+      "expected_calibration_error",
+      "race_probability_sum_error",
+      "top_place_slots_capture"
+    ]
+  },
+  "verdicts": {
+    "source_blocked": "FRESH_2026_FORWARD_SOURCE_BLOCKED",
+    "insufficient_sample": "FRESH_2026_FORWARD_INSUFFICIENT_SAMPLE",
+    "slot2_recovery_confirmed": "FRESH_2026_FORWARD_SLOT2_RECOVERY_CONFIRMED",
+    "slot2_recovery_not_confirmed": "FRESH_2026_FORWARD_SLOT2_RECOVERY_NOT_CONFIRMED"
+  },
+  "implementation_snapshot": {
+    "base_commit": "e82525a8af0440be459982b0d46bba8378fe32c0",
+    "source_sha256": {
+      "src/horse_bet_lab/research/historical_ability_source.py": "d4014ccd5d50d27e506a84e0965cc9c6289f56c36b96ad8808603711e8de97b7",
+      "src/horse_bet_lab/research/historical_ability_models.py": "6059a1ab4111d195d8508c7b85ab833a3f81e8dbf32e4fadef0c2bf6547a33a2",
+      "src/horse_bet_lab/research/historical_signal_robustness.py": "940cfa8811e28ed689d6478c748ab2c8caf2d1cae23ae2da7d96362133458f90",
+      "src/horse_bet_lab/research/small_field_failure_audit.py": "792125534cf4faa0e7183f21dc09a7cfe72da0bf6849ac3c37cc109378ee15da",
+      "src/horse_bet_lab/research/no_popularity_rebase.py": "eeb09ee8f9d554b1534209e1f172211abe082207942708cb59fbf1ed301eccb2"
+    }
+  },
+  "phase_boundary": {
+    "current_phase_scope": "preregistration_amendment_only",
+    "forbidden_before_contract_merge": [
+      "inspect_forward_window_source_rows_or_coverage",
+      "compute_forward_window_model_metrics",
+      "change_features_models_hyperparameters_or_success_thresholds_after_forward_collection_starts",
+      "optimize_roi_payout_bet_selection_or_stakes"
+    ],
+    "allowed_after_merge_before_evaluation_unlock": [
+      "read_only_schema_audit",
+      "date_and_identity_coverage_monitoring_without_model_predictions_or_metrics",
+      "missingness_and_join_diagnostics_without_outcome_conditioning"
+    ],
+    "next_phase_after_merge": "no_popularity_prospective_collection_readiness_and_schema_audit",
+    "roi_or_betting_used": false
+  }
+}

--- a/configs/phase658_2026_forward_preregistered_validation.sha256
+++ b/configs/phase658_2026_forward_preregistered_validation.sha256
@@ -1,0 +1,1 @@
+e41ef20367a3c08643b5a43b2cc5b48ea7b89b207d9fa41e6117c82609c711db phase658_2026_forward_preregistered_validation.json

--- a/docs/phase654_2026_forward_preregistered_validation.md
+++ b/docs/phase654_2026_forward_preregistered_validation.md
@@ -1,5 +1,8 @@
 # Phase654 2026 Forward Preregistered Validation
 
+> Superseded for prospective execution by the additive Phase658 no-popularity amendment. This
+> Phase654 document and its checksummed JSON remain unchanged evidence in the registration lineage.
+
 ## Purpose
 
 Phase652 found a small incremental probability signal from strictly-prior horse history.

--- a/docs/phase658_no_popularity_forward_preregistration.md
+++ b/docs/phase658_no_popularity_forward_preregistration.md
@@ -1,0 +1,56 @@
+# Phase658 No-Popularity Forward Preregistration Amendment
+
+## Purpose
+
+Phase654 registered a prospective 2026 evaluation, but its market baseline still depended on a
+historical `popularity` column. Phase655 showed that the column came from result-side SED and had no
+confirmed equivalent decision-time carrier. Phase656 selected a no-popularity market contract, and
+Phase657 reproduced the historical Phase651-653 conclusions under that contract without reading
+2026 data.
+
+Phase658 records a new, immutable amendment instead of rewriting the Phase654 artifact. The original
+contract and checksum remain part of the lineage.
+
+## Amended market contract
+
+The prospective market model uses exactly this ordered feature vector:
+
+1. `log1p(win_odds)`;
+2. `log1p(place_basis_odds)`.
+
+`popularity` is excluded. Training-fit preprocessing remains median imputation, missing indicators,
+mean centering, and population-standard-deviation scaling. The selected market logistic `C` changes
+from `3.0` to `1.0`, as selected by the Phase657 no-popularity rerun. The residual logistic remains
+fixed at `C=1.0`.
+
+Periods, target, place-slot rule, model roles, comparisons, cross-fit settings, bootstrap settings,
+minimum sample gates, success rules, and ROI prohibition remain unchanged from Phase654.
+
+## Lineage and immutability
+
+The amended JSON records:
+
+- the exact SHA-256 of the superseded Phase654 contract;
+- the Phase655-657 verdicts and merge commits;
+- the no-popularity market feature order and transforms;
+- the source hashes of the historical ability and robustness implementation at the Phase657 merge;
+- that no 2026 data, fresh-2025 claim, ROI, payout, threshold, stake, or betting rule was used.
+
+The Phase658 JSON has its own SHA-256 sidecar. Validation fails when the amendment bytes, Phase654
+lineage, market features, preprocessing, hyperparameters, evidence, implementation hashes, periods,
+comparisons, statistical rules, or phase boundary change.
+
+## Freshness boundary
+
+The evaluation window remains 2026-07-20 through 2026-12-31 and stays locked until 2027-01-01.
+Before unlock, only schema, date, identity, missingness, and join-completeness monitoring is allowed.
+Model predictions, metrics, and outcome-conditioned diagnostics remain forbidden.
+
+No complete 2026 dataset is expected or required by this phase. Phase658 is registration-only.
+
+## Validation
+
+```bash
+PYTHONPATH=src .venv/bin/python \
+  scripts/phase658_preregister_no_popularity_forward_validation.py
+```

--- a/scripts/phase658_preregister_no_popularity_forward_validation.py
+++ b/scripts/phase658_preregister_no_popularity_forward_validation.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from horse_bet_lab.research.preregistered_validation_amendment import (
+    load_amended_registered_contract,
+    verify_implementation_snapshot,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate the Phase658 no-popularity forward preregistration amendment.",
+    )
+    parser.add_argument(
+        "--contract",
+        type=Path,
+        default=Path("configs/phase658_2026_forward_preregistered_validation.json"),
+    )
+    parser.add_argument(
+        "--checksum",
+        type=Path,
+        default=Path("configs/phase658_2026_forward_preregistered_validation.sha256"),
+    )
+    parser.add_argument(
+        "--superseded-contract",
+        type=Path,
+        default=Path("configs/phase654_2026_forward_preregistered_validation.json"),
+    )
+    parser.add_argument(
+        "--superseded-checksum",
+        type=Path,
+        default=Path("configs/phase654_2026_forward_preregistered_validation.sha256"),
+    )
+    parser.add_argument("--repository-root", type=Path, default=Path("."))
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    registration = load_amended_registered_contract(
+        args.contract,
+        args.checksum,
+        args.superseded_contract,
+        args.superseded_checksum,
+    )
+    verify_implementation_snapshot(registration, args.repository_root)
+    print(json.dumps(registration.summary, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/horse_bet_lab/research/preregistered_validation_amendment.py
+++ b/src/horse_bet_lab/research/preregistered_validation_amendment.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from horse_bet_lab.research.preregistered_validation_contract import (
+    EXPECTED_COMPARISONS,
+    EXPECTED_MODELS,
+    load_registered_contract,
+)
+
+VALID_AMENDED_VERDICT = "PHASE658_NO_POPULARITY_FORWARD_PREREGISTRATION_VALID"
+
+EXPECTED_TOP_LEVEL_KEYS = {
+    "contract_version",
+    "phase",
+    "research_question",
+    "amendment",
+    "freshness",
+    "periods",
+    "data_contract",
+    "market_contract",
+    "fixed_models",
+    "comparisons",
+    "analysis",
+    "verdicts",
+    "implementation_snapshot",
+    "phase_boundary",
+}
+EXPECTED_MARKET_CONTRACT = {
+    "contract_id": "phase658_no_popularity_decision_time_market_v1",
+    "feature_order": ["win_odds", "place_basis_odds"],
+    "feature_transforms": {
+        "win_odds": "log1p",
+        "place_basis_odds": "log1p",
+    },
+    "numeric_preprocessing": (
+        "training-fit median imputation, missing indicators, mean centering, "
+        "and population-standard-deviation scaling"
+    ),
+    "excluded_features": ["popularity"],
+    "excluded_feature_reason": (
+        "the historical popularity field is carried by result-side SED and is not a "
+        "confirmed decision-time input"
+    ),
+    "applies_to": [
+        "M1C_race_constrained_market",
+        "M5_full_pooled",
+        "M5_history_only_pooled",
+        "M5_full_slot2_only",
+        "M5_history_only_slot2_only",
+    ],
+}
+EXPECTED_IMPLEMENTATION_FILES = {
+    "src/horse_bet_lab/research/historical_ability_source.py": (
+        "d4014ccd5d50d27e506a84e0965cc9c6289f56c36b96ad8808603711e8de97b7"
+    ),
+    "src/horse_bet_lab/research/historical_ability_models.py": (
+        "6059a1ab4111d195d8508c7b85ab833a3f81e8dbf32e4fadef0c2bf6547a33a2"
+    ),
+    "src/horse_bet_lab/research/historical_signal_robustness.py": (
+        "940cfa8811e28ed689d6478c748ab2c8caf2d1cae23ae2da7d96362133458f90"
+    ),
+    "src/horse_bet_lab/research/small_field_failure_audit.py": (
+        "792125534cf4faa0e7183f21dc09a7cfe72da0bf6849ac3c37cc109378ee15da"
+    ),
+    "src/horse_bet_lab/research/no_popularity_rebase.py": (
+        "eeb09ee8f9d554b1534209e1f172211abe082207942708cb59fbf1ed301eccb2"
+    ),
+}
+
+
+@dataclass(frozen=True)
+class AmendedRegisteredValidationContract:
+    payload: Mapping[str, Any]
+    sha256: str
+    superseded_sha256: str
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        periods = _as_mapping(self.payload["periods"], "periods")
+        market = _as_mapping(self.payload["market_contract"], "market_contract")
+        return {
+            "verdict": VALID_AMENDED_VERDICT,
+            "phase": self.payload["phase"],
+            "contract_sha256": self.sha256,
+            "superseded_contract_sha256": self.superseded_sha256,
+            "market_contract_id": market["contract_id"],
+            "market_feature_order": market["feature_order"],
+            "excluded_market_features": market["excluded_features"],
+            "training_window": [periods["training_start"], periods["training_end"]],
+            "evaluation_window": [periods["evaluation_start"], periods["evaluation_end"]],
+            "evaluation_unlock_date": periods["evaluation_unlock_date"],
+            "2026_data_used_for_amendment": self.payload["amendment"]["evidence"]["2026_data_used"],
+            "roi_or_betting_used": self.payload["phase_boundary"]["roi_or_betting_used"],
+        }
+
+
+def load_amended_registered_contract(
+    contract_path: Path,
+    checksum_path: Path,
+    superseded_contract_path: Path,
+    superseded_checksum_path: Path,
+) -> AmendedRegisteredValidationContract:
+    superseded = load_registered_contract(
+        superseded_contract_path,
+        superseded_checksum_path,
+    )
+    raw = contract_path.read_bytes()
+    actual_sha256 = hashlib.sha256(raw).hexdigest()
+    expected_sha256 = _read_checksum(checksum_path, contract_path.name)
+    if actual_sha256 != expected_sha256:
+        raise ValueError(
+            f"amended contract checksum mismatch: expected {expected_sha256}, got {actual_sha256}"
+        )
+    payload = json.loads(raw)
+    if not isinstance(payload, dict):
+        raise ValueError("amended contract root must be an object")
+    validate_amended_contract(payload, superseded.payload, superseded.sha256)
+    return AmendedRegisteredValidationContract(
+        payload=payload,
+        sha256=actual_sha256,
+        superseded_sha256=superseded.sha256,
+    )
+
+
+def validate_amended_contract(
+    payload: Mapping[str, Any],
+    superseded_payload: Mapping[str, Any],
+    superseded_sha256: str,
+) -> None:
+    _expect_exact_keys(payload, EXPECTED_TOP_LEVEL_KEYS, "amended contract")
+    _expect(payload["contract_version"] == 2, "contract_version must be 2")
+    _expect(payload["phase"] == "Phase658", "phase must be Phase658")
+    _expect(
+        payload["research_question"] == superseded_payload["research_question"],
+        "research question changed",
+    )
+
+    amendment = _as_mapping(payload["amendment"], "amendment")
+    _expect_exact_keys(
+        amendment,
+        {
+            "supersedes_phase",
+            "superseded_contract_path",
+            "superseded_contract_sha256",
+            "reason",
+            "evidence",
+        },
+        "amendment",
+    )
+    _expect(
+        amendment.get("supersedes_phase") == "Phase654",
+        "amendment must supersede Phase654",
+    )
+    _expect(
+        amendment.get("superseded_contract_path")
+        == "configs/phase654_2026_forward_preregistered_validation.json",
+        "superseded contract path changed",
+    )
+    _expect(
+        amendment.get("superseded_contract_sha256") == superseded_sha256,
+        "superseded contract checksum changed",
+    )
+    _expect(
+        amendment.get("reason")
+        == (
+            "Phase655 found that historical popularity came from result-side SED and was not "
+            "prospectively reproducible. Phase656 selected a no-popularity decision-time market "
+            "contract, and Phase657 reproduced the historical Phase651-653 conclusions under "
+            "that contract before the forward window began."
+        ),
+        "amendment reason changed",
+    )
+    _validate_evidence(_as_mapping(amendment.get("evidence"), "amendment.evidence"))
+
+    _expect(payload["freshness"] == superseded_payload["freshness"], "freshness rules changed")
+    _expect(payload["periods"] == superseded_payload["periods"], "periods changed")
+
+    expected_data_contract = dict(_as_mapping(superseded_payload["data_contract"], "data_contract"))
+    expected_data_contract["market_surface"] = "Phase657 no-popularity decision-time market surface"
+    _expect(payload["data_contract"] == expected_data_contract, "data contract changed")
+    _expect(payload["market_contract"] == EXPECTED_MARKET_CONTRACT, "market contract changed")
+    _expect(payload["fixed_models"] == EXPECTED_MODELS, "fixed model definitions changed")
+
+    comparisons = _as_sequence(payload["comparisons"], "comparisons")
+    _expect(
+        comparisons == list(EXPECTED_COMPARISONS.values()),
+        "comparison definitions changed",
+    )
+
+    expected_analysis = dict(_as_mapping(superseded_payload["analysis"], "analysis"))
+    expected_analysis["market_logistic_c"] = 1.0
+    _expect(payload["analysis"] == expected_analysis, "analysis contract changed")
+    _expect(payload["verdicts"] == superseded_payload["verdicts"], "verdicts changed")
+
+    implementation = _as_mapping(payload["implementation_snapshot"], "implementation_snapshot")
+    _expect_exact_keys(
+        implementation,
+        {"base_commit", "source_sha256"},
+        "implementation_snapshot",
+    )
+    _expect(
+        implementation.get("base_commit") == "e82525a8af0440be459982b0d46bba8378fe32c0",
+        "implementation base commit changed",
+    )
+    _expect(
+        implementation.get("source_sha256") == EXPECTED_IMPLEMENTATION_FILES,
+        "implementation source checksums changed",
+    )
+
+    boundary = _as_mapping(payload["phase_boundary"], "phase_boundary")
+    _expect(
+        boundary.get("current_phase_scope") == "preregistration_amendment_only",
+        "phase scope changed",
+    )
+    _expect(boundary.get("roi_or_betting_used") is False, "ROI or betting must remain disabled")
+    _expect(
+        boundary.get("next_phase_after_merge")
+        == "no_popularity_prospective_collection_readiness_and_schema_audit",
+        "next phase changed",
+    )
+    for key in ("forbidden_before_contract_merge", "allowed_after_merge_before_evaluation_unlock"):
+        _expect(
+            boundary.get(key) == superseded_payload["phase_boundary"][key],
+            f"phase_boundary.{key} changed",
+        )
+
+
+def verify_implementation_snapshot(
+    registration: AmendedRegisteredValidationContract,
+    repository_root: Path,
+) -> None:
+    source_sha256 = _as_mapping(
+        registration.payload["implementation_snapshot"]["source_sha256"],
+        "implementation_snapshot.source_sha256",
+    )
+    for relative_path, expected_sha256 in source_sha256.items():
+        path = repository_root / str(relative_path)
+        if not path.is_file():
+            raise ValueError(f"registered implementation source is missing: {relative_path}")
+        actual_sha256 = hashlib.sha256(path.read_bytes()).hexdigest()
+        if actual_sha256 != expected_sha256:
+            raise ValueError(
+                f"registered implementation source changed: {relative_path}; "
+                f"expected {expected_sha256}, got {actual_sha256}"
+            )
+
+
+def _validate_evidence(evidence: Mapping[str, Any]) -> None:
+    expected = {
+        "phase655_verdict": "FORWARD_COLLECTION_READINESS_BLOCKED",
+        "phase655_merge_commit": "4b05bb8c2c883baedf7953c893cab44e25e57be2",
+        "phase656_verdict": "DECISION_TIME_MARKET_FEATURE_CANDIDATE_SELECTED",
+        "phase656_selected_safe_variant": "no_popularity",
+        "phase656_merge_commit": "9ed80d519abf049e750d3b58c5e6ae098043e2e3",
+        "phase657_verdict": "NO_POPULARITY_REBASE_HISTORICAL_CONCLUSIONS_REPRODUCED",
+        "phase657_recommendation": (
+            "AMEND_PREREGISTRATION_TO_NO_POPULARITY_BEFORE_FORWARD_MODEL_EVALUATION"
+        ),
+        "phase657_merge_commit": "e82525a8af0440be459982b0d46bba8378fe32c0",
+        "2026_data_used": False,
+        "2025_claimed_fresh": False,
+        "roi_or_betting_used": False,
+    }
+    _expect(evidence == expected, "amendment evidence changed")
+
+
+def _read_checksum(checksum_path: Path, expected_name: str) -> str:
+    parts = checksum_path.read_text(encoding="utf-8").strip().split()
+    if len(parts) != 2 or parts[1] != expected_name:
+        raise ValueError("checksum file must contain '<sha256> <contract filename>'")
+    digest = parts[0]
+    if len(digest) != 64 or any(character not in "0123456789abcdef" for character in digest):
+        raise ValueError("checksum must be a lowercase SHA-256 digest")
+    return digest
+
+
+def _expect_exact_keys(value: Mapping[str, Any], expected: set[str], label: str) -> None:
+    actual = set(value)
+    if actual != expected:
+        raise ValueError(
+            f"{label} keys changed: missing={sorted(expected - actual)}, "
+            f"unexpected={sorted(actual - expected)}"
+        )
+
+
+def _as_mapping(value: Any, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{label} must be an object")
+    return value
+
+
+def _as_sequence(value: Any, label: str) -> Sequence[Any]:
+    if not isinstance(value, list):
+        raise ValueError(f"{label} must be an array")
+    return value
+
+
+def _expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)

--- a/tests/test_preregistered_validation_amendment.py
+++ b/tests/test_preregistered_validation_amendment.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from horse_bet_lab.research.preregistered_validation_amendment import (
+    EXPECTED_IMPLEMENTATION_FILES,
+    VALID_AMENDED_VERDICT,
+    load_amended_registered_contract,
+    validate_amended_contract,
+    verify_implementation_snapshot,
+)
+from horse_bet_lab.research.preregistered_validation_contract import (
+    load_registered_contract,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT_PATH = ROOT / "configs/phase658_2026_forward_preregistered_validation.json"
+CHECKSUM_PATH = ROOT / "configs/phase658_2026_forward_preregistered_validation.sha256"
+SUPERSEDED_CONTRACT_PATH = ROOT / "configs/phase654_2026_forward_preregistered_validation.json"
+SUPERSEDED_CHECKSUM_PATH = ROOT / "configs/phase654_2026_forward_preregistered_validation.sha256"
+
+
+def _load_payloads() -> tuple[dict[str, object], dict[str, object], str]:
+    amended = json.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
+    superseded = load_registered_contract(SUPERSEDED_CONTRACT_PATH, SUPERSEDED_CHECKSUM_PATH)
+    return amended, dict(superseded.payload), superseded.sha256
+
+
+def test_repository_amendment_is_locked_and_valid() -> None:
+    registration = load_amended_registered_contract(
+        CONTRACT_PATH,
+        CHECKSUM_PATH,
+        SUPERSEDED_CONTRACT_PATH,
+        SUPERSEDED_CHECKSUM_PATH,
+    )
+
+    assert registration.summary["verdict"] == VALID_AMENDED_VERDICT
+    assert registration.summary["market_feature_order"] == [
+        "win_odds",
+        "place_basis_odds",
+    ]
+    assert registration.summary["excluded_market_features"] == ["popularity"]
+    assert registration.summary["evaluation_window"] == ["2026-07-20", "2026-12-31"]
+    assert registration.summary["2026_data_used_for_amendment"] is False
+    assert registration.summary["roi_or_betting_used"] is False
+
+
+def test_phase654_lineage_remains_valid_and_unchanged() -> None:
+    superseded = load_registered_contract(SUPERSEDED_CONTRACT_PATH, SUPERSEDED_CHECKSUM_PATH)
+    amended = json.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
+
+    assert superseded.sha256 == "90070eca4bf576a2752dfdc4ba18d91367236664bfa17b782e88586653089297"
+    assert amended["amendment"]["superseded_contract_sha256"] == superseded.sha256
+    assert superseded.payload["analysis"]["market_logistic_c"] == 3.0
+    assert amended["analysis"]["market_logistic_c"] == 1.0
+
+
+def test_checksum_detects_amendment_mutation(tmp_path: Path) -> None:
+    mutated = CONTRACT_PATH.read_text(encoding="utf-8").replace(
+        '"market_logistic_c": 1.0',
+        '"market_logistic_c": 3.0',
+    )
+    contract_path = tmp_path / CONTRACT_PATH.name
+    contract_path.write_text(mutated, encoding="utf-8")
+    checksum_path = tmp_path / CHECKSUM_PATH.name
+    checksum_path.write_text(CHECKSUM_PATH.read_text(encoding="utf-8"), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="amended contract checksum mismatch"):
+        load_amended_registered_contract(
+            contract_path,
+            checksum_path,
+            SUPERSEDED_CONTRACT_PATH,
+            SUPERSEDED_CHECKSUM_PATH,
+        )
+
+
+def test_validator_rejects_popularity_reintroduction() -> None:
+    amended, superseded, superseded_sha256 = _load_payloads()
+    amended["market_contract"]["feature_order"].append("popularity")  # type: ignore[index,union-attr]
+
+    with pytest.raises(ValueError, match="market contract changed"):
+        validate_amended_contract(amended, superseded, superseded_sha256)
+
+
+def test_validator_rejects_market_hyperparameter_change() -> None:
+    amended, superseded, superseded_sha256 = _load_payloads()
+    amended["analysis"]["market_logistic_c"] = 3.0  # type: ignore[index]
+
+    with pytest.raises(ValueError, match="analysis contract changed"):
+        validate_amended_contract(amended, superseded, superseded_sha256)
+
+
+def test_validator_rejects_superseded_checksum_change() -> None:
+    amended, superseded, superseded_sha256 = _load_payloads()
+    amended["amendment"]["superseded_contract_sha256"] = "0" * 64  # type: ignore[index]
+
+    with pytest.raises(ValueError, match="superseded contract checksum changed"):
+        validate_amended_contract(amended, superseded, superseded_sha256)
+
+
+def test_implementation_snapshot_matches_phase657_merge_sources() -> None:
+    registration = load_amended_registered_contract(
+        CONTRACT_PATH,
+        CHECKSUM_PATH,
+        SUPERSEDED_CONTRACT_PATH,
+        SUPERSEDED_CHECKSUM_PATH,
+    )
+
+    verify_implementation_snapshot(registration, ROOT)
+
+
+def test_implementation_snapshot_detects_source_mutation(tmp_path: Path) -> None:
+    registration = load_amended_registered_contract(
+        CONTRACT_PATH,
+        CHECKSUM_PATH,
+        SUPERSEDED_CONTRACT_PATH,
+        SUPERSEDED_CHECKSUM_PATH,
+    )
+    for relative_path in EXPECTED_IMPLEMENTATION_FILES:
+        source = ROOT / relative_path
+        target = tmp_path / relative_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(source.read_bytes())
+    changed_path = tmp_path / next(iter(EXPECTED_IMPLEMENTATION_FILES))
+    changed_path.write_bytes(changed_path.read_bytes() + b"\n# changed\n")
+
+    with pytest.raises(ValueError, match="registered implementation source changed"):
+        verify_implementation_snapshot(registration, tmp_path)
+
+
+def test_checksum_file_matches_exact_repository_bytes() -> None:
+    expected_digest, expected_name = CHECKSUM_PATH.read_text(encoding="utf-8").split()
+
+    assert expected_name == CONTRACT_PATH.name
+    assert expected_digest == hashlib.sha256(CONTRACT_PATH.read_bytes()).hexdigest()


### PR DESCRIPTION
## What changed

- add a Phase658 checksummed amendment instead of mutating the Phase654 preregistration
- freeze the decision-time market vector to `win_odds` and `place_basis_odds`
- explicitly exclude result-side `popularity`
- update the historically selected market logistic regularization from `C=3.0` to `C=1.0`
- record Phase655-657 evidence, merge lineage, and implementation source hashes
- add a validator, CLI, documentation, and mutation-detection tests

## Why

Phase655 showed that the legacy popularity field came from result-side SED and could not be reproduced prospectively. Phase656 selected the no-popularity market contract, and Phase657 reproduced the historical Phase651-653 conclusions under that contract without using 2026 data. The prospective contract therefore needed an auditable amendment before the forward window begins.

## Boundary

- no 2026 rows inspected or used
- no model predictions or forward metrics computed
- no ROI, payout, selection, stake, or BET logic used
- the original Phase654 JSON and checksum remain unchanged

## Validation

- 35 related tests passed
- Ruff check and format passed
- strict Mypy passed
- compileall passed
- Phase658 validator passed
- JSON and SHA-256 sidecar validated
