### PR TITLE
Phase660: add prospective collection monitor

### DIFF
--- a/docs/phase660_prospective_collection_monitor.md
+++ b/docs/phase660_prospective_collection_monitor.md
@@ -1,0 +1,53 @@
+# Phase660 Prospective Collection Monitor
+
+## Purpose
+
+Phase659 confirmed that the checksummed no-popularity contract has a reproducible static collection
+path. Phase660 adds the pre-unlock monitor permitted by Phase658: schema, date, identity, file hash,
+snapshot status, and required-odds missingness only.
+
+The monitor never trains or runs a probability model. It does not read result files or compute
+performance metrics.
+
+## Allowed input
+
+Each input must be a contract-stage forward snapshot CSV with at least:
+
+- `race_key`;
+- `horse_number`;
+- `win_odds`;
+- `place_basis_odds`;
+- `odds_observation_timestamp` with timezone;
+- `carrier_identity`;
+- `snapshot_status`.
+
+Files are hashed with SHA-256. Identities must be unique across all supplied snapshots, and
+observation dates must remain inside 2026-07-20 through 2026-12-31.
+
+## Hard boundary
+
+The monitor rejects files containing target, finish, result, payout, return, profit, prediction,
+probability, model-metric, ROI, stake, decision, or betting columns. It reports only aggregate
+collection coverage and never copies horse-level values into its reports.
+
+## Verdicts
+
+- `FORWARD_COLLECTION_MONITOR_WAITING_FOR_WINDOW`: correct before 2026-07-20 with no input;
+- `FORWARD_COLLECTION_MONITOR_WAITING_FOR_SNAPSHOTS`: window open, no snapshot supplied;
+- `FORWARD_COLLECTION_MONITOR_OK`: supplied snapshots satisfy the collection contract;
+- `FORWARD_COLLECTION_MONITOR_BLOCKED`: schema, date, identity, odds, or boundary violation.
+
+## Commands
+
+Before the window starts:
+
+```bash
+PYTHONPATH=src .venv/bin/python scripts/phase660_prospective_collection_monitor.py \
+  --as-of-date 2026-07-19 \
+  --output-dir data/artifacts/phase660_prospective_collection_monitor
+```
+
+During the window, add one `--snapshot` argument for every append-only contract snapshot file.
+Do not point this monitor at reconciliation, prediction, decision, result, or payout artifacts.
+
+Generated monitoring reports remain uncommitted.

--- a/scripts/phase660_prospective_collection_monitor.py
+++ b/scripts/phase660_prospective_collection_monitor.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import date
+from pathlib import Path
+
+from horse_bet_lab.research.prospective_collection_monitor import (
+    MONITOR_BLOCKED,
+    run_prospective_collection_monitor,
+    write_prospective_collection_monitor,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Monitor prospective snapshot schema and coverage without outcomes or metrics.",
+    )
+    parser.add_argument(
+        "--contract",
+        type=Path,
+        default=Path("configs/phase658_2026_forward_preregistered_validation.json"),
+    )
+    parser.add_argument(
+        "--checksum",
+        type=Path,
+        default=Path("configs/phase658_2026_forward_preregistered_validation.sha256"),
+    )
+    parser.add_argument(
+        "--superseded-contract",
+        type=Path,
+        default=Path("configs/phase654_2026_forward_preregistered_validation.json"),
+    )
+    parser.add_argument(
+        "--superseded-checksum",
+        type=Path,
+        default=Path("configs/phase654_2026_forward_preregistered_validation.sha256"),
+    )
+    parser.add_argument("--repository-root", type=Path, default=Path("."))
+    parser.add_argument("--snapshot", type=Path, action="append", default=[])
+    parser.add_argument("--as-of-date", type=date.fromisoformat, default=date.today())
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("data/artifacts/phase660_prospective_collection_monitor"),
+    )
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    result = run_prospective_collection_monitor(
+        contract_path=args.contract,
+        checksum_path=args.checksum,
+        superseded_contract_path=args.superseded_contract,
+        superseded_checksum_path=args.superseded_checksum,
+        repository_root=args.repository_root,
+        snapshot_paths=tuple(args.snapshot),
+        as_of_date=args.as_of_date,
+    )
+    write_prospective_collection_monitor(result, args.output_dir)
+    print(json.dumps(result.summary, ensure_ascii=False, indent=2, sort_keys=True))
+    return int(result.summary["final_verdict"] == MONITOR_BLOCKED)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/horse_bet_lab/research/prospective_collection_monitor.py
+++ b/src/horse_bet_lab/research/prospective_collection_monitor.py
@@ -1,0 +1,502 @@
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+from collections import Counter
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+from horse_bet_lab.forward_test.contracts import PLACE_FORWARD_TEST_SNAPSHOT_STATUSES
+from horse_bet_lab.research.preregistered_validation_amendment import (
+    load_amended_registered_contract,
+    verify_implementation_snapshot,
+)
+
+WAITING_FOR_WINDOW = "FORWARD_COLLECTION_MONITOR_WAITING_FOR_WINDOW"
+WAITING_FOR_SNAPSHOTS = "FORWARD_COLLECTION_MONITOR_WAITING_FOR_SNAPSHOTS"
+MONITOR_OK = "FORWARD_COLLECTION_MONITOR_OK"
+MONITOR_BLOCKED = "FORWARD_COLLECTION_MONITOR_BLOCKED"
+
+REQUIRED_COLUMNS = (
+    "race_key",
+    "horse_number",
+    "win_odds",
+    "place_basis_odds",
+    "odds_observation_timestamp",
+    "carrier_identity",
+    "snapshot_status",
+)
+FILE_REPORT_COLUMNS = (
+    "snapshot_path",
+    "sha256",
+    "row_count",
+    "header_status",
+)
+DATE_REPORT_COLUMNS = (
+    "observation_date",
+    "row_count",
+    "race_count",
+)
+FORBIDDEN_EXACT_COLUMNS = frozenset(
+    {
+        "target",
+        "target_value",
+        "is_place",
+        "finish_position",
+        "finish_order",
+        "result",
+        "result_code",
+        "payout",
+        "return",
+        "profit",
+        "hit",
+        "prediction",
+        "prediction_probability",
+        "probability",
+        "log_loss",
+        "brier_score",
+        "roi",
+        "stake",
+        "bet_action",
+        "decision_reason",
+        "no_bet_reason",
+    }
+)
+FORBIDDEN_PREFIXES = (
+    "target_",
+    "result_",
+    "finish_",
+    "payout_",
+    "return_",
+    "profit_",
+    "prediction_",
+    "metric_",
+    "roi_",
+    "stake_",
+    "bet_",
+)
+
+
+@dataclass(frozen=True)
+class ProspectiveCollectionMonitorResult:
+    summary: dict[str, Any]
+    file_rows: tuple[dict[str, Any], ...]
+    date_rows: tuple[dict[str, Any], ...]
+    blockers: tuple[str, ...]
+
+
+def run_prospective_collection_monitor(
+    *,
+    contract_path: Path,
+    checksum_path: Path,
+    superseded_contract_path: Path,
+    superseded_checksum_path: Path,
+    repository_root: Path,
+    snapshot_paths: Sequence[Path],
+    as_of_date: date,
+) -> ProspectiveCollectionMonitorResult:
+    registration = load_amended_registered_contract(
+        contract_path,
+        checksum_path,
+        superseded_contract_path,
+        superseded_checksum_path,
+    )
+    verify_implementation_snapshot(registration, repository_root)
+    periods = registration.payload["periods"]
+    evaluation_start = date.fromisoformat(str(periods["evaluation_start"]))
+    evaluation_end = date.fromisoformat(str(periods["evaluation_end"]))
+    unlock_date = date.fromisoformat(str(periods["evaluation_unlock_date"]))
+
+    if not snapshot_paths:
+        verdict = WAITING_FOR_WINDOW if as_of_date < evaluation_start else WAITING_FOR_SNAPSHOTS
+        if as_of_date >= unlock_date:
+            verdict = MONITOR_BLOCKED
+        waiting_blockers = (
+            ("Phase660 pre-unlock monitor is no longer applicable on or after unlock",)
+            if verdict == MONITOR_BLOCKED
+            else ()
+        )
+        return _empty_result(
+            verdict=verdict,
+            blockers=waiting_blockers,
+            registration_sha256=registration.sha256,
+            evaluation_start=evaluation_start,
+            evaluation_end=evaluation_end,
+            unlock_date=unlock_date,
+            as_of_date=as_of_date,
+        )
+
+    blockers: list[str] = []
+    if as_of_date < evaluation_start:
+        blockers.append("snapshot inspection is forbidden before the prospective window starts")
+    if as_of_date >= unlock_date:
+        blockers.append("Phase660 pre-unlock monitor is no longer applicable on or after unlock")
+
+    seen_identities: dict[tuple[str, int], Path] = {}
+    date_counts: Counter[str] = Counter()
+    date_races: dict[str, set[str]] = {}
+    file_rows: list[dict[str, Any]] = []
+    total_rows = 0
+    total_ok_rows = 0
+    total_failure_rows = 0
+    total_missing_win_odds = 0
+    total_missing_place_basis_odds = 0
+    all_races: set[str] = set()
+
+    for snapshot_path in snapshot_paths:
+        file_summary, rows = _read_snapshot_file(snapshot_path, blockers)
+        file_rows.append(file_summary)
+        for row_index, row in rows:
+            total_rows += 1
+            parsed = _validate_collection_row(
+                row,
+                snapshot_path=snapshot_path,
+                row_index=row_index,
+                evaluation_start=evaluation_start,
+                evaluation_end=evaluation_end,
+                blockers=blockers,
+            )
+            if parsed is None:
+                continue
+            (
+                race_key,
+                horse_number,
+                observation_date,
+                snapshot_status,
+                win_missing,
+                place_missing,
+            ) = parsed
+            identity = (race_key, horse_number)
+            previous_path = seen_identities.get(identity)
+            if previous_path is not None:
+                blockers.append(
+                    "duplicate prospective identity across snapshots: "
+                    f"{race_key}:{horse_number} in {previous_path} and {snapshot_path}"
+                )
+            else:
+                seen_identities[identity] = snapshot_path
+            observation_label = observation_date.isoformat()
+            date_counts[observation_label] += 1
+            date_races.setdefault(observation_label, set()).add(race_key)
+            all_races.add(race_key)
+            total_ok_rows += int(snapshot_status == "ok")
+            total_failure_rows += int(snapshot_status != "ok")
+            total_missing_win_odds += int(win_missing)
+            total_missing_place_basis_odds += int(place_missing)
+
+    if total_rows == 0:
+        blockers.append("prospective snapshot inputs contain no data rows")
+
+    date_rows = tuple(
+        {
+            "observation_date": observation_date,
+            "row_count": date_counts[observation_date],
+            "race_count": len(date_races[observation_date]),
+        }
+        for observation_date in sorted(date_counts)
+    )
+    deduplicated_blockers = tuple(dict.fromkeys(blockers))
+    verdict = MONITOR_OK if not deduplicated_blockers else MONITOR_BLOCKED
+    summary = {
+        "final_verdict": verdict,
+        "phase658_contract_sha256": registration.sha256,
+        "as_of_date": as_of_date.isoformat(),
+        "evaluation_window": {
+            "start": evaluation_start.isoformat(),
+            "end": evaluation_end.isoformat(),
+            "unlock_date": unlock_date.isoformat(),
+        },
+        "snapshot_file_count": len(snapshot_paths),
+        "row_count": total_rows,
+        "unique_identity_count": len(seen_identities),
+        "race_count": len(all_races),
+        "observation_date_count": len(date_counts),
+        "ok_snapshot_row_count": total_ok_rows,
+        "failed_snapshot_row_count": total_failure_rows,
+        "missing_win_odds_count": total_missing_win_odds,
+        "missing_place_basis_odds_count": total_missing_place_basis_odds,
+        "blocker_count": len(deduplicated_blockers),
+        "blockers": list(deduplicated_blockers),
+        "coverage_monitoring_only": True,
+        "source_outcomes_inspected": False,
+        "model_predictions_computed_or_inspected": False,
+        "model_metrics_computed_or_inspected": False,
+        "roi_or_betting_used": False,
+        "recommendation": (
+            "CONTINUE_APPEND_ONLY_PROSPECTIVE_SNAPSHOT_COLLECTION"
+            if verdict == MONITOR_OK
+            else "RESOLVE_COLLECTION_CONTRACT_VIOLATIONS_BEFORE_CONTINUING"
+        ),
+    }
+    return ProspectiveCollectionMonitorResult(
+        summary=summary,
+        file_rows=tuple(file_rows),
+        date_rows=date_rows,
+        blockers=deduplicated_blockers,
+    )
+
+
+def write_prospective_collection_monitor(
+    result: ProspectiveCollectionMonitorResult,
+    output_dir: Path,
+) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "phase660_summary.json").write_text(
+        json.dumps(result.summary, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    _write_csv(
+        output_dir / "phase660_files.csv",
+        result.file_rows,
+        fieldnames=FILE_REPORT_COLUMNS,
+    )
+    _write_csv(
+        output_dir / "phase660_dates.csv",
+        result.date_rows,
+        fieldnames=DATE_REPORT_COLUMNS,
+    )
+    (output_dir / "phase660_findings.md").write_text(
+        _findings_markdown(result),
+        encoding="utf-8",
+    )
+
+
+def _read_snapshot_file(
+    snapshot_path: Path,
+    blockers: list[str],
+) -> tuple[dict[str, Any], tuple[tuple[int, dict[str, str]], ...]]:
+    if not snapshot_path.is_file():
+        blockers.append(f"prospective snapshot file is missing: {snapshot_path}")
+        return (
+            {
+                "snapshot_path": str(snapshot_path),
+                "sha256": "",
+                "row_count": 0,
+                "header_status": "MISSING",
+            },
+            (),
+        )
+    raw = snapshot_path.read_bytes()
+    digest = hashlib.sha256(raw).hexdigest()
+    with snapshot_path.open("r", encoding="utf-8-sig", newline="") as file:
+        reader = csv.DictReader(file)
+        fieldnames = tuple(reader.fieldnames or ())
+        normalized = tuple(value.strip().lower() for value in fieldnames)
+        duplicate_headers = len(set(normalized)) != len(normalized)
+        if duplicate_headers:
+            blockers.append(f"duplicate header columns in prospective snapshot: {snapshot_path}")
+        missing_required = sorted(set(REQUIRED_COLUMNS) - set(normalized))
+        forbidden = sorted(value for value in normalized if _is_forbidden_column(value))
+        if missing_required:
+            blockers.append(
+                "prospective snapshot missing required columns in "
+                f"{snapshot_path}: {missing_required}"
+            )
+        if forbidden:
+            blockers.append(
+                f"prospective snapshot contains forbidden outcome/model columns in "
+                f"{snapshot_path}: {forbidden}"
+            )
+        header_valid = not duplicate_headers and not missing_required and not forbidden
+        if not header_valid:
+            return (
+                {
+                    "snapshot_path": str(snapshot_path),
+                    "sha256": digest,
+                    "row_count": 0,
+                    "header_status": "FAIL",
+                },
+                (),
+            )
+        rows = tuple(
+            (
+                row_index,
+                {str(key).strip().lower(): (value or "").strip() for key, value in row.items()},
+            )
+            for row_index, row in enumerate(reader, start=2)
+        )
+    return (
+        {
+            "snapshot_path": str(snapshot_path),
+            "sha256": digest,
+            "row_count": len(rows),
+            "header_status": "PASS",
+        },
+        rows,
+    )
+
+
+def _validate_collection_row(
+    row: dict[str, str],
+    *,
+    snapshot_path: Path,
+    row_index: int,
+    evaluation_start: date,
+    evaluation_end: date,
+    blockers: list[str],
+) -> tuple[str, int, date, str, bool, bool] | None:
+    prefix = f"{snapshot_path}:{row_index}"
+    race_key = row.get("race_key", "")
+    if len(race_key) != 8 or not race_key.isdigit():
+        blockers.append(f"invalid race_key at {prefix}: {race_key!r}")
+        return None
+    try:
+        horse_number = int(row.get("horse_number", ""))
+    except ValueError:
+        blockers.append(f"invalid horse_number at {prefix}: {row.get('horse_number', '')!r}")
+        return None
+    if horse_number <= 0:
+        blockers.append(f"horse_number must be positive at {prefix}: {horse_number}")
+        return None
+
+    timestamp_text = row.get("odds_observation_timestamp", "")
+    try:
+        timestamp = datetime.fromisoformat(timestamp_text.replace("Z", "+00:00"))
+    except ValueError:
+        blockers.append(f"invalid odds_observation_timestamp at {prefix}: {timestamp_text!r}")
+        return None
+    if timestamp.tzinfo is None:
+        blockers.append(f"odds_observation_timestamp lacks timezone at {prefix}")
+        return None
+    observation_date = timestamp.date()
+    if not evaluation_start <= observation_date <= evaluation_end:
+        blockers.append(
+            "observation date outside registered window at "
+            f"{prefix}: {observation_date.isoformat()}"
+        )
+
+    snapshot_status = row.get("snapshot_status", "")
+    if snapshot_status not in PLACE_FORWARD_TEST_SNAPSHOT_STATUSES:
+        blockers.append(f"invalid snapshot_status at {prefix}: {snapshot_status!r}")
+        return None
+    if row.get("carrier_identity", "") == "":
+        blockers.append(f"missing carrier_identity at {prefix}")
+
+    win_missing = row.get("win_odds", "") == ""
+    place_missing = row.get("place_basis_odds", "") == ""
+    if snapshot_status == "ok":
+        _validate_positive_odds(row.get("win_odds", ""), "win_odds", prefix, blockers)
+        _validate_positive_odds(
+            row.get("place_basis_odds", ""),
+            "place_basis_odds",
+            prefix,
+            blockers,
+        )
+    return (
+        race_key,
+        horse_number,
+        observation_date,
+        snapshot_status,
+        win_missing,
+        place_missing,
+    )
+
+
+def _validate_positive_odds(
+    value: str,
+    field_name: str,
+    prefix: str,
+    blockers: list[str],
+) -> None:
+    try:
+        parsed = float(value)
+    except ValueError:
+        blockers.append(f"invalid {field_name} at {prefix}: {value!r}")
+        return
+    if parsed <= 0.0:
+        blockers.append(f"{field_name} must be positive at {prefix}: {parsed}")
+
+
+def _is_forbidden_column(column_name: str) -> bool:
+    return column_name in FORBIDDEN_EXACT_COLUMNS or column_name.startswith(FORBIDDEN_PREFIXES)
+
+
+def _empty_result(
+    *,
+    verdict: str,
+    blockers: Sequence[str],
+    registration_sha256: str,
+    evaluation_start: date,
+    evaluation_end: date,
+    unlock_date: date,
+    as_of_date: date,
+) -> ProspectiveCollectionMonitorResult:
+    summary = {
+        "final_verdict": verdict,
+        "phase658_contract_sha256": registration_sha256,
+        "as_of_date": as_of_date.isoformat(),
+        "evaluation_window": {
+            "start": evaluation_start.isoformat(),
+            "end": evaluation_end.isoformat(),
+            "unlock_date": unlock_date.isoformat(),
+        },
+        "snapshot_file_count": 0,
+        "row_count": 0,
+        "unique_identity_count": 0,
+        "race_count": 0,
+        "observation_date_count": 0,
+        "ok_snapshot_row_count": 0,
+        "failed_snapshot_row_count": 0,
+        "missing_win_odds_count": 0,
+        "missing_place_basis_odds_count": 0,
+        "blocker_count": len(blockers),
+        "blockers": list(blockers),
+        "coverage_monitoring_only": True,
+        "source_outcomes_inspected": False,
+        "model_predictions_computed_or_inspected": False,
+        "model_metrics_computed_or_inspected": False,
+        "roi_or_betting_used": False,
+        "recommendation": {
+            WAITING_FOR_WINDOW: "WAIT_UNTIL_REGISTERED_EVALUATION_WINDOW",
+            WAITING_FOR_SNAPSHOTS: "WAIT_FOR_FIRST_CONTRACT_SNAPSHOT",
+            MONITOR_BLOCKED: "STOP_PHASE660_AFTER_UNLOCK",
+        }[verdict],
+    }
+    return ProspectiveCollectionMonitorResult(
+        summary=summary,
+        file_rows=(),
+        date_rows=(),
+        blockers=tuple(blockers),
+    )
+
+
+def _write_csv(
+    path: Path,
+    rows: Iterable[dict[str, Any]],
+    *,
+    fieldnames: Sequence[str],
+) -> None:
+    rows = tuple(rows)
+    with path.open("w", encoding="utf-8", newline="") as file:
+        writer = csv.DictWriter(file, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _findings_markdown(result: ProspectiveCollectionMonitorResult) -> str:
+    return "\n".join(
+        [
+            "# Phase660 Prospective Collection Monitor",
+            "",
+            "## Verdict",
+            "",
+            f"`{result.summary['final_verdict']}`",
+            "",
+            "## Coverage-only summary",
+            "",
+            f"- Snapshot files: `{result.summary['snapshot_file_count']}`",
+            f"- Rows: `{result.summary['row_count']}`",
+            f"- Races: `{result.summary['race_count']}`",
+            f"- Blockers: `{result.summary['blocker_count']}`",
+            "",
+            "## Boundary",
+            "",
+            "The monitor rejects outcome, prediction, model-metric, ROI, stake, and betting "
+            "columns. It reports only schema, file hashes, dates, identities, status, and "
+            "required-odds missingness.",
+            "",
+        ]
+    )

--- a/tests/test_prospective_collection_monitor.py
+++ b/tests/test_prospective_collection_monitor.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import csv
+from datetime import date
+from pathlib import Path
+
+from horse_bet_lab.research.prospective_collection_monitor import (
+    MONITOR_BLOCKED,
+    MONITOR_OK,
+    WAITING_FOR_SNAPSHOTS,
+    WAITING_FOR_WINDOW,
+    ProspectiveCollectionMonitorResult,
+    run_prospective_collection_monitor,
+    write_prospective_collection_monitor,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT_PATH = ROOT / "configs/phase658_2026_forward_preregistered_validation.json"
+CHECKSUM_PATH = ROOT / "configs/phase658_2026_forward_preregistered_validation.sha256"
+SUPERSEDED_CONTRACT_PATH = ROOT / "configs/phase654_2026_forward_preregistered_validation.json"
+SUPERSEDED_CHECKSUM_PATH = ROOT / "configs/phase654_2026_forward_preregistered_validation.sha256"
+
+
+def _run(
+    snapshot_paths: tuple[Path, ...],
+    as_of_date: date,
+) -> ProspectiveCollectionMonitorResult:
+    return run_prospective_collection_monitor(
+        contract_path=CONTRACT_PATH,
+        checksum_path=CHECKSUM_PATH,
+        superseded_contract_path=SUPERSEDED_CONTRACT_PATH,
+        superseded_checksum_path=SUPERSEDED_CHECKSUM_PATH,
+        repository_root=ROOT,
+        snapshot_paths=snapshot_paths,
+        as_of_date=as_of_date,
+    )
+
+
+def _write_snapshot(path: Path, *, include_forbidden_column: bool = False) -> None:
+    fieldnames = [
+        "race_key",
+        "horse_number",
+        "win_odds",
+        "place_basis_odds",
+        "odds_observation_timestamp",
+        "carrier_identity",
+        "snapshot_status",
+    ]
+    if include_forbidden_column:
+        fieldnames.append("finish_position")
+    with path.open("w", encoding="utf-8", newline="") as file:
+        writer = csv.DictWriter(file, fieldnames=fieldnames)
+        writer.writeheader()
+        for horse_number in range(1, 9):
+            row = {
+                "race_key": "26010101",
+                "horse_number": horse_number,
+                "win_odds": 2.0 + horse_number,
+                "place_basis_odds": 1.1 + horse_number / 10,
+                "odds_observation_timestamp": "2026-07-20T15:20:00+09:00",
+                "carrier_identity": "jrdb_oz_pre_race_v1",
+                "snapshot_status": "ok",
+            }
+            if include_forbidden_column:
+                row["finish_position"] = horse_number
+            writer.writerow(row)
+
+
+def test_empty_monitor_waits_before_window() -> None:
+    result = _run((), date(2026, 7, 19))
+
+    assert result.summary["final_verdict"] == WAITING_FOR_WINDOW
+    assert result.summary["row_count"] == 0
+    assert result.summary["source_outcomes_inspected"] is False
+
+
+def test_empty_monitor_waits_for_first_snapshot_inside_window() -> None:
+    result = _run((), date(2026, 7, 20))
+
+    assert result.summary["final_verdict"] == WAITING_FOR_SNAPSHOTS
+    assert result.summary["blockers"] == []
+
+
+def test_valid_contract_snapshot_reports_coverage_only(tmp_path: Path) -> None:
+    snapshot_path = tmp_path / "input_snapshot.csv"
+    _write_snapshot(snapshot_path)
+
+    result = _run((snapshot_path,), date(2026, 7, 20))
+
+    assert result.summary["final_verdict"] == MONITOR_OK
+    assert result.summary["row_count"] == 8
+    assert result.summary["unique_identity_count"] == 8
+    assert result.summary["race_count"] == 1
+    assert result.summary["ok_snapshot_row_count"] == 8
+    assert result.summary["model_predictions_computed_or_inspected"] is False
+    assert result.summary["model_metrics_computed_or_inspected"] is False
+    assert result.summary["roi_or_betting_used"] is False
+    assert len(result.file_rows[0]["sha256"]) == 64
+
+
+def test_monitor_rejects_outcome_column_before_reading_values(tmp_path: Path) -> None:
+    snapshot_path = tmp_path / "contaminated_snapshot.csv"
+    _write_snapshot(snapshot_path, include_forbidden_column=True)
+
+    result = _run((snapshot_path,), date(2026, 7, 20))
+
+    assert result.summary["final_verdict"] == MONITOR_BLOCKED
+    assert any("forbidden outcome/model columns" in blocker for blocker in result.blockers)
+    assert result.summary["row_count"] == 0
+    assert result.file_rows[0]["row_count"] == 0
+    assert result.file_rows[0]["header_status"] == "FAIL"
+    assert result.summary["source_outcomes_inspected"] is False
+
+
+def test_monitor_rejects_duplicate_identity_across_files(tmp_path: Path) -> None:
+    first = tmp_path / "first.csv"
+    second = tmp_path / "second.csv"
+    _write_snapshot(first)
+    _write_snapshot(second)
+
+    result = _run((first, second), date(2026, 7, 20))
+
+    assert result.summary["final_verdict"] == MONITOR_BLOCKED
+    assert any("duplicate prospective identity" in blocker for blocker in result.blockers)
+
+
+def test_writer_emits_no_prediction_or_performance_artifacts(tmp_path: Path) -> None:
+    result = _run((), date(2026, 7, 19))
+    output_dir = tmp_path / "monitor"
+    write_prospective_collection_monitor(result, output_dir)
+
+    assert {path.name for path in output_dir.iterdir()} == {
+        "phase660_summary.json",
+        "phase660_files.csv",
+        "phase660_dates.csv",
+        "phase660_findings.md",
+    }
+    assert not any(
+        forbidden in path.name
+        for path in output_dir.iterdir()
+        for forbidden in ("prediction", "metric", "roi", "payout", "bet")
+    )
+    assert (
+        (output_dir / "phase660_files.csv")
+        .read_text(encoding="utf-8")
+        .startswith("snapshot_path,sha256,row_count,header_status")
+    )
+    assert (
+        (output_dir / "phase660_dates.csv")
+        .read_text(encoding="utf-8")
+        .startswith("observation_date,row_count,race_count")
+    )


### PR DESCRIPTION
## Summary

- add a fail-closed pre-unlock monitor for Phase658 prospective snapshot schema and coverage
- reject outcome, prediction, model-metric, ROI, stake, decision, and betting columns before reading row values
- report only aggregate dates, identities, file hashes, snapshot status, and required-odds missingness
- preserve the 2026-07-20 through 2026-12-31 evaluation window and the 2027-01-01 unlock boundary

## Validation

- `ruff check`: passed
- strict `mypy`: passed
- `compileall`: passed
- related Phase654-660 tests: `41 passed`
- current-date no-input rehearsal: `FORWARD_COLLECTION_MONITOR_WAITING_FOR_WINDOW`
- summary JSON validated with `json.tool`

## Boundary

- no real 2026 snapshot rows, outcomes, predictions, model metrics, ROI, or betting artifacts were inspected
- generated monitor reports stayed under `/private/tmp` and were not committed
- the original dirty worktree was not modified
