### PR TITLE
Phase661: add collection-only prospective operations path

### DIFF
--- a/docs/phase661_prospective_collection_ops.md
+++ b/docs/phase661_prospective_collection_ops.md
@@ -1,0 +1,48 @@
+# Phase661 Prospective Collection Operations
+
+## Purpose
+
+Phase661 supplies the operational path that Phase660 deliberately did not own. It converts a
+local, already-extracted official JRDB TYB/OZ source directory into one append-only contract
+snapshot and immediately runs the Phase660 coverage-only monitor.
+
+The path stops after monitoring. It never invokes the forward model runner, produces predictions
+or betting decisions, reads outcomes, or computes model metrics and ROI.
+
+## Preconditions
+
+- the current date is inside 2026-07-20 through 2026-12-31;
+- the source directory contains the intended `TYB*.txt` and `OZ*.txt` files only;
+- timestamps are timezone-aware and describe the actual observation;
+- the unit id starts with the observation date, for example `20260720_tokyo_hakodate`;
+- local JRDB authentication and archive acquisition have already completed outside this command.
+
+## Command
+
+```bash
+PYTHONPATH=src .venv/bin/python scripts/phase661_prospective_collection_ops.py \
+  --unit-id 20260720_replace_with_meeting \
+  --source-dir /absolute/path/to/extracted/jrdb/files \
+  --input-source-url https://jrdb.com/replace-with-actual-source \
+  --input-source-timestamp 2026-07-20T15:20:00+09:00 \
+  --odds-observation-timestamp 2026-07-20T15:20:00+09:00
+```
+
+Do not use placeholder metadata for a real collection unit. The command has no overwrite flag:
+an existing unit directory is a hard error.
+
+## Outputs
+
+Under `data/forward_test/prospective_collection/<unit_id>/`:
+
+- `raw/input_snapshot_raw.csv` and its intake manifest;
+- `contract/input_snapshot_<unit_id>.csv` plus aggregate bridge provenance;
+- `monitor/phase660_*` coverage-only reports;
+- `notes/phase661_collection_summary.json` with file hashes and aggregate counts.
+
+These are local collection artifacts and remain uncommitted.
+
+## Current boundary
+
+As of 2026-07-19 the registered window has not started, so a real run must not be performed yet.
+Synthetic test fixtures exercise the complete path without claiming that 2026 data exists.

--- a/scripts/phase661_prospective_collection_ops.py
+++ b/scripts/phase661_prospective_collection_ops.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import date
+from pathlib import Path
+
+from horse_bet_lab.research.prospective_collection_ops import (
+    DEFAULT_CARRIER_IDENTITY,
+    DEFAULT_INPUT_SOURCE_NAME,
+    ProspectiveCollectionOpsConfig,
+    run_prospective_collection_ops,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Collect an append-only TYB/OZ contract snapshot and run coverage-only monitoring."
+        )
+    )
+    parser.add_argument("--unit-id", required=True)
+    parser.add_argument("--source-dir", type=Path, required=True)
+    parser.add_argument(
+        "--output-root",
+        type=Path,
+        default=Path("data/forward_test/prospective_collection"),
+    )
+    parser.add_argument("--input-source-name", default=DEFAULT_INPUT_SOURCE_NAME)
+    parser.add_argument("--input-source-url", required=True)
+    parser.add_argument("--input-source-timestamp", required=True)
+    parser.add_argument("--odds-observation-timestamp", required=True)
+    parser.add_argument("--carrier-identity", default=DEFAULT_CARRIER_IDENTITY)
+    parser.add_argument("--as-of-date", type=date.fromisoformat, default=date.today())
+    parser.add_argument("--repository-root", type=Path, default=Path("."))
+    parser.add_argument(
+        "--contract",
+        type=Path,
+        default=Path("configs/phase658_2026_forward_preregistered_validation.json"),
+    )
+    parser.add_argument(
+        "--checksum",
+        type=Path,
+        default=Path("configs/phase658_2026_forward_preregistered_validation.sha256"),
+    )
+    parser.add_argument(
+        "--superseded-contract",
+        type=Path,
+        default=Path("configs/phase654_2026_forward_preregistered_validation.json"),
+    )
+    parser.add_argument(
+        "--superseded-checksum",
+        type=Path,
+        default=Path("configs/phase654_2026_forward_preregistered_validation.sha256"),
+    )
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    try:
+        result = run_prospective_collection_ops(
+            ProspectiveCollectionOpsConfig(
+                unit_id=args.unit_id,
+                source_dir=args.source_dir,
+                output_root=args.output_root,
+                input_source_name=args.input_source_name,
+                input_source_url=args.input_source_url,
+                input_source_timestamp=args.input_source_timestamp,
+                odds_observation_timestamp=args.odds_observation_timestamp,
+                carrier_identity=args.carrier_identity,
+                as_of_date=args.as_of_date,
+                repository_root=args.repository_root,
+                contract_path=args.contract,
+                checksum_path=args.checksum,
+                superseded_contract_path=args.superseded_contract,
+                superseded_checksum_path=args.superseded_checksum,
+            )
+        )
+    except (FileExistsError, FileNotFoundError, ValueError) as exc:
+        print(
+            json.dumps(
+                {"status": "blocked", "reason": str(exc)},
+                ensure_ascii=False,
+                indent=2,
+                sort_keys=True,
+            ),
+            file=sys.stderr,
+        )
+        return 1
+    print(
+        json.dumps(
+            {
+                "unit_id": result.unit_id,
+                "run_dir": str(result.run_dir),
+                "contract_snapshot_path": str(result.contract_snapshot_path),
+                "row_count": result.row_count,
+                "race_count": result.race_count,
+                "monitor_verdict": result.monitor_verdict,
+            },
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/horse_bet_lab/research/prospective_collection_ops.py
+++ b/src/horse_bet_lab/research/prospective_collection_ops.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+
+from horse_bet_lab.forward_test.raw_snapshot_intake import (
+    build_default_raw_snapshot_intake_manifest,
+    write_raw_snapshot_intake_manifest,
+)
+from horse_bet_lab.forward_test.snapshot_bridge import (
+    PlaceForwardSnapshotBridgeConfig,
+    SnapshotBridgeColumns,
+    SnapshotBridgeSourceConfig,
+    run_snapshot_bridge,
+)
+from horse_bet_lab.jrdb_ingestion.oz_pre_race_adapter import discover_oz_source_paths
+from horse_bet_lab.jrdb_ingestion.tyb_oz_pre_race_adapter import (
+    discover_tyb_source_paths,
+    run_tyb_oz_pre_race_adapter,
+)
+from horse_bet_lab.research.prospective_collection_monitor import (
+    MONITOR_OK,
+    WAITING_FOR_SNAPSHOTS,
+    run_prospective_collection_monitor,
+    write_prospective_collection_monitor,
+)
+
+UNIT_ID_PATTERN = re.compile(r"^[0-9]{8}_[a-z0-9][a-z0-9_-]*$")
+DEFAULT_CARRIER_IDENTITY = "place_forward_live_snapshot_v1"
+DEFAULT_INPUT_SOURCE_NAME = "jrdb_tyb_oz_official"
+
+
+@dataclass(frozen=True)
+class ProspectiveCollectionOpsConfig:
+    unit_id: str
+    source_dir: Path
+    output_root: Path
+    input_source_name: str
+    input_source_url: str
+    input_source_timestamp: str
+    odds_observation_timestamp: str
+    carrier_identity: str
+    as_of_date: date
+    repository_root: Path
+    contract_path: Path
+    checksum_path: Path
+    superseded_contract_path: Path
+    superseded_checksum_path: Path
+
+
+@dataclass(frozen=True)
+class ProspectiveCollectionOpsResult:
+    unit_id: str
+    run_dir: Path
+    raw_snapshot_path: Path
+    contract_snapshot_path: Path
+    monitor_output_dir: Path
+    collection_summary_path: Path
+    row_count: int
+    race_count: int
+    monitor_verdict: str
+
+
+def run_prospective_collection_ops(
+    config: ProspectiveCollectionOpsConfig,
+) -> ProspectiveCollectionOpsResult:
+    observation_timestamp = _require_timestamp(
+        config.odds_observation_timestamp,
+        "odds_observation_timestamp",
+    )
+    source_timestamp = _require_timestamp(
+        config.input_source_timestamp,
+        "input_source_timestamp",
+    )
+    _validate_config(
+        config,
+        observation_timestamp=observation_timestamp,
+        source_timestamp=source_timestamp,
+    )
+    readiness = run_prospective_collection_monitor(
+        contract_path=config.contract_path,
+        checksum_path=config.checksum_path,
+        superseded_contract_path=config.superseded_contract_path,
+        superseded_checksum_path=config.superseded_checksum_path,
+        repository_root=config.repository_root,
+        snapshot_paths=(),
+        as_of_date=config.as_of_date,
+    )
+    if readiness.summary["final_verdict"] != WAITING_FOR_SNAPSHOTS:
+        raise ValueError(
+            "prospective collection is not open for snapshot intake: "
+            f"{readiness.summary['final_verdict']}"
+        )
+
+    tyb_source_paths = discover_tyb_source_paths(config.source_dir)
+    oz_source_paths = discover_oz_source_paths(config.source_dir)
+    run_dir = config.output_root / config.unit_id
+    if run_dir.exists():
+        raise FileExistsError(
+            "prospective collection is append-only and refuses an existing unit directory: "
+            f"{run_dir}"
+        )
+    raw_dir = run_dir / "raw"
+    contract_dir = run_dir / "contract"
+    notes_dir = run_dir / "notes"
+    monitor_output_dir = run_dir / "monitor"
+    for path in (raw_dir, contract_dir, notes_dir, monitor_output_dir):
+        path.mkdir(parents=True, exist_ok=False)
+
+    raw_snapshot_path = raw_dir / "input_snapshot_raw.csv"
+    adapter_result = run_tyb_oz_pre_race_adapter(
+        tyb_source_paths=tyb_source_paths,
+        oz_source_paths=oz_source_paths,
+        output_path=raw_snapshot_path,
+        force=False,
+    )
+
+    intake_manifest = build_default_raw_snapshot_intake_manifest(
+        unit_id=config.unit_id,
+        raw_snapshot_path=raw_snapshot_path,
+        source_family="jrdb_tyb_oz_pre_race_v1",
+        input_source_name=config.input_source_name,
+        input_source_url=config.input_source_url,
+        input_source_timestamp=config.input_source_timestamp,
+        odds_observation_timestamp=config.odds_observation_timestamp,
+        carrier_identity=config.carrier_identity,
+    )
+    write_raw_snapshot_intake_manifest(
+        raw_dir / "raw_snapshot_intake_manifest.json",
+        intake_manifest,
+    )
+
+    contract_snapshot_path = contract_dir / f"input_snapshot_{config.unit_id}.csv"
+    bridge_result = run_snapshot_bridge(
+        PlaceForwardSnapshotBridgeConfig(
+            name=f"phase661_prospective_collection_{config.unit_id}",
+            output_path=contract_snapshot_path,
+            columns=SnapshotBridgeColumns(),
+            strict_race_key=True,
+            infer_snapshot_status=True,
+            write_json_copy=False,
+            sources=(
+                SnapshotBridgeSourceConfig(
+                    path=raw_snapshot_path,
+                    odds_observation_timestamp=config.odds_observation_timestamp,
+                    input_source_name=config.input_source_name,
+                    input_source_url=config.input_source_url,
+                    input_source_timestamp=config.input_source_timestamp,
+                    carrier_identity=config.carrier_identity,
+                    default_retry_count=1,
+                    default_timeout_seconds=15.0,
+                    default_popularity_input_source=None,
+                ),
+            ),
+        )
+    )
+
+    monitor_result = run_prospective_collection_monitor(
+        contract_path=config.contract_path,
+        checksum_path=config.checksum_path,
+        superseded_contract_path=config.superseded_contract_path,
+        superseded_checksum_path=config.superseded_checksum_path,
+        repository_root=config.repository_root,
+        snapshot_paths=(contract_snapshot_path,),
+        as_of_date=config.as_of_date,
+    )
+    write_prospective_collection_monitor(monitor_result, monitor_output_dir)
+    if monitor_result.summary["final_verdict"] != MONITOR_OK:
+        raise ValueError(
+            "prospective contract snapshot failed Phase660 monitoring: "
+            f"{monitor_result.summary['blockers']}"
+        )
+
+    collection_summary_path = notes_dir / "phase661_collection_summary.json"
+    summary = {
+        "unit_id": config.unit_id,
+        "source_dir": str(config.source_dir),
+        "source_file_count": len(tyb_source_paths) + len(oz_source_paths),
+        "source_file_sha256": {
+            str(path): _sha256(path) for path in (*tyb_source_paths, *oz_source_paths)
+        },
+        "raw_snapshot_path": str(raw_snapshot_path),
+        "raw_snapshot_sha256": _sha256(raw_snapshot_path),
+        "contract_snapshot_path": str(contract_snapshot_path),
+        "contract_snapshot_sha256": _sha256(contract_snapshot_path),
+        "adapter_row_count": adapter_result.row_count,
+        "adapter_race_count": adapter_result.race_count,
+        "bridge_record_count": bridge_result.record_count,
+        "monitor_verdict": monitor_result.summary["final_verdict"],
+        "coverage_monitoring_only": True,
+        "model_runner_invoked": False,
+        "predictions_or_decisions_generated": False,
+        "outcomes_or_model_metrics_inspected": False,
+        "roi_or_betting_used": False,
+    }
+    collection_summary_path.write_text(
+        json.dumps(summary, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return ProspectiveCollectionOpsResult(
+        unit_id=config.unit_id,
+        run_dir=run_dir,
+        raw_snapshot_path=raw_snapshot_path,
+        contract_snapshot_path=contract_snapshot_path,
+        monitor_output_dir=monitor_output_dir,
+        collection_summary_path=collection_summary_path,
+        row_count=adapter_result.row_count,
+        race_count=adapter_result.race_count,
+        monitor_verdict=str(monitor_result.summary["final_verdict"]),
+    )
+
+
+def _validate_config(
+    config: ProspectiveCollectionOpsConfig,
+    *,
+    observation_timestamp: datetime,
+    source_timestamp: datetime,
+) -> None:
+    if UNIT_ID_PATTERN.fullmatch(config.unit_id) is None:
+        raise ValueError(
+            "unit_id must match YYYYMMDD_<lowercase-label> using letters, digits, underscores, "
+            f"or hyphens: {config.unit_id!r}"
+        )
+    observation_date = observation_timestamp.date()
+    if config.as_of_date != observation_date:
+        raise ValueError(
+            "as_of_date must equal the odds observation date: "
+            f"{config.as_of_date.isoformat()} != {observation_date.isoformat()}"
+        )
+    if not config.unit_id.startswith(observation_date.strftime("%Y%m%d_")):
+        raise ValueError("unit_id date prefix must equal the odds observation date")
+    if source_timestamp > observation_timestamp:
+        raise ValueError("input_source_timestamp must not be later than odds observation timestamp")
+    for field_name, value in (
+        ("input_source_name", config.input_source_name),
+        ("input_source_url", config.input_source_url),
+        ("carrier_identity", config.carrier_identity),
+    ):
+        if value.strip() == "":
+            raise ValueError(f"{field_name} must be non-empty")
+
+
+def _require_timestamp(value: str, field_name: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"{field_name} must be ISO-8601: {value!r}") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"{field_name} must include a timezone")
+    return parsed
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()

--- a/tests/test_prospective_collection_ops.py
+++ b/tests/test_prospective_collection_ops.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from horse_bet_lab.research.prospective_collection_monitor import MONITOR_OK
+from horse_bet_lab.research.prospective_collection_ops import (
+    ProspectiveCollectionOpsConfig,
+    run_prospective_collection_ops,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _config(
+    tmp_path: Path, *, as_of_date: date = date(2026, 7, 20)
+) -> ProspectiveCollectionOpsConfig:
+    return ProspectiveCollectionOpsConfig(
+        unit_id="20260720_synthetic_meeting",
+        source_dir=tmp_path / "source",
+        output_root=tmp_path / "collection",
+        input_source_name="jrdb_tyb_oz_official",
+        input_source_url="https://example.invalid/jrdb/tyb-oz",
+        input_source_timestamp="2026-07-20T15:19:00+09:00",
+        odds_observation_timestamp="2026-07-20T15:20:00+09:00",
+        carrier_identity="place_forward_live_snapshot_v1",
+        as_of_date=as_of_date,
+        repository_root=ROOT,
+        contract_path=ROOT / "configs/phase658_2026_forward_preregistered_validation.json",
+        checksum_path=ROOT / "configs/phase658_2026_forward_preregistered_validation.sha256",
+        superseded_contract_path=(
+            ROOT / "configs/phase654_2026_forward_preregistered_validation.json"
+        ),
+        superseded_checksum_path=(
+            ROOT / "configs/phase654_2026_forward_preregistered_validation.sha256"
+        ),
+    )
+
+
+def _write_sources(source_dir: Path) -> None:
+    source_dir.mkdir(parents=True)
+    race_key = "06261101"
+    tyb_lines = [
+        _make_tyb_line(
+            race_key=race_key,
+            horse_number=horse_number,
+            odds_index=horse_number / 10,
+            win_odds=2.0 + horse_number,
+            place_odds_low=1.0 + horse_number / 10,
+            odds_observation_time_hhmm="1520",
+        )
+        for horse_number in range(1, 9)
+    ]
+    (source_dir / "TYB260720.txt").write_bytes(b"\r\n".join(tyb_lines) + b"\r\n")
+    (source_dir / "OZ260720.txt").write_bytes(
+        _make_oz_line(
+            race_key=race_key,
+            headcount=8,
+            win_basis_odds=tuple(2.2 + number for number in range(1, 9)),
+            place_basis_odds=tuple(1.1 + number / 10 for number in range(1, 9)),
+        )
+        + b"\r\n"
+    )
+
+
+def test_collection_ops_builds_contract_and_monitor_without_model_outputs(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    _write_sources(config.source_dir)
+
+    result = run_prospective_collection_ops(config)
+
+    assert result.row_count == 8
+    assert result.race_count == 1
+    assert result.monitor_verdict == MONITOR_OK
+    assert result.contract_snapshot_path.is_file()
+    monitor_summary = json.loads(
+        (result.monitor_output_dir / "phase660_summary.json").read_text(encoding="utf-8")
+    )
+    assert monitor_summary["final_verdict"] == MONITOR_OK
+    collection_summary = json.loads(result.collection_summary_path.read_text(encoding="utf-8"))
+    assert collection_summary["model_runner_invoked"] is False
+    assert collection_summary["predictions_or_decisions_generated"] is False
+    assert collection_summary["outcomes_or_model_metrics_inspected"] is False
+    names = {path.name for path in result.run_dir.rglob("*") if path.is_file()}
+    assert not any(
+        forbidden in name
+        for name in names
+        for forbidden in ("prediction", "decision", "metric", "roi", "payout", "result")
+    )
+
+
+def test_collection_ops_refuses_before_registered_window_without_writing(tmp_path: Path) -> None:
+    config = replace(
+        _config(tmp_path, as_of_date=date(2026, 7, 19)),
+        unit_id="20260719_synthetic_meeting",
+        input_source_timestamp="2026-07-19T15:19:00+09:00",
+        odds_observation_timestamp="2026-07-19T15:20:00+09:00",
+    )
+    _write_sources(config.source_dir)
+
+    with pytest.raises(ValueError, match="collection is not open"):
+        run_prospective_collection_ops(config)
+
+    assert not config.output_root.exists()
+
+
+def test_collection_ops_refuses_existing_append_only_unit(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    _write_sources(config.source_dir)
+    (config.output_root / config.unit_id).mkdir(parents=True)
+
+    with pytest.raises(FileExistsError, match="append-only"):
+        run_prospective_collection_ops(config)
+
+
+def test_collection_ops_rejects_source_timestamp_after_observation(tmp_path: Path) -> None:
+    config = replace(
+        _config(tmp_path),
+        input_source_timestamp="2026-07-20T15:21:00+09:00",
+    )
+
+    with pytest.raises(ValueError, match="must not be later"):
+        run_prospective_collection_ops(config)
+
+
+def _make_tyb_line(
+    *,
+    race_key: str,
+    horse_number: int,
+    odds_index: float,
+    win_odds: float,
+    place_odds_low: float,
+    odds_observation_time_hhmm: str,
+) -> bytes:
+    chunks = [
+        race_key[:8].ljust(8),
+        f"{horse_number:02d}",
+        f"{0.0:>5.1f}",
+        f"{0.0:>5.1f}",
+        f"{0.0:>5.1f}",
+        f"{odds_index:>5.1f}",
+        f"{0.0:>5.1f}",
+        f"{0.0:>5.1f}",
+        f"{0.0:>5.1f}",
+        "0",
+        "0",
+        "0",
+        "00000",
+        "ﾃｽﾄｼﾞｮｷ".ljust(12),
+        "540",
+        "0",
+        "10",
+        "2",
+        f"{win_odds:>6.1f}",
+        f"{place_odds_low:>6.1f}",
+        odds_observation_time_hhmm[:4].rjust(4),
+        "484",
+        "- 6",
+        " ",
+        " ",
+        " ",
+        "2",
+        "7",
+        "1538",
+        " " * 23,
+    ]
+    return "".join(chunks).encode("cp932")
+
+
+def _make_oz_line(
+    *,
+    race_key: str,
+    headcount: int,
+    win_basis_odds: tuple[float, ...],
+    place_basis_odds: tuple[float, ...],
+) -> bytes:
+    win_text = "".join(f"{value:>5.1f}" for value in win_basis_odds)
+    place_text = "".join(f"{value:>5.1f}" for value in place_basis_odds)
+    return f"{race_key[:8].ljust(8)}{headcount:02d}{win_text}{' ' * 12}{place_text}".encode("ascii")


### PR DESCRIPTION
## Summary

- add a collection-only official TYB/OZ path for the registered prospective window
- convert extracted JRDB sources into an append-only contract snapshot
- invoke Phase660 coverage monitoring immediately after the bridge
- stop before any model runner, prediction, decision, result reconciliation, metric, ROI, or betting step
- reject runs before the window and refuse overwriting an existing collection unit

## Validation

- `ruff check`: passed
- strict `mypy`: passed
- `compileall`: passed
- focused Phase660-661 tests: `10 passed`
- related contract/readiness/adapter tests: `60 passed`
- CLI guard rehearsal on 2026-07-19: blocked before source discovery and created no output

## Boundary

- the end-to-end collection rehearsal used synthetic TYB/OZ fixtures only
- no real 2026 source rows, outcomes, predictions, model metrics, ROI, or betting artifacts were inspected
- actual archive acquisition and credentials remain external prerequisites
- the original dirty worktree was not modified
