### PR TITLE
Phase662: connect JRDB ingestion to prospective collection

### DIFF
--- a/docs/phase662_auto_collection_handoff.md
+++ b/docs/phase662_auto_collection_handoff.md
@@ -1,0 +1,33 @@
+# Phase662 Automatic Collection Handoff
+
+Phase662 connects the existing local JRDB archive downloader/extractor to the Phase661
+collection-only path with `handoff.mode = "forward_collection_tyb_oz_v1"`.
+
+Unlike the older `forward_pre_race_*` modes, this mode requires no dataset, model version, DuckDB,
+threshold, or betting configuration. It stops after the append-only contract snapshot and Phase660
+coverage monitor are written.
+
+```json
+{
+  "trigger_kind": "manual",
+  "detected_at": "2026-07-20T15:20:00+09:00",
+  "archives": [
+    {
+      "name": "replace-with-archive.zip",
+      "source_uri": "/absolute/path/to/archive.zip"
+    }
+  ],
+  "handoff": {
+    "mode": "forward_collection_tyb_oz_v1",
+    "ingest_ready_files": false,
+    "unit_id": "20260720_replace_with_meeting",
+    "input_source_name": "jrdb_tyb_oz_official",
+    "input_source_url": "https://jrdb.com/replace-with-actual-source",
+    "input_source_timestamp": "2026-07-20T15:19:00+09:00",
+    "odds_observation_timestamp": "2026-07-20T15:20:00+09:00"
+  }
+}
+```
+
+Run it through the existing `horse_bet_lab.jrdb_ingestion.cli`. Real collection remains blocked
+until the registered window opens and an actual TYB/OZ archive is locally available.

--- a/docs/runbooks/jrdb_auto_ingestion_mvp.md
+++ b/docs/runbooks/jrdb_auto_ingestion_mvp.md
@@ -65,6 +65,7 @@ repo には入れない。
 `mode = "forward_pre_race_contract_like_csv_v1"` は従来どおり sanctioned local contract-like CSV を source にする開発/fixture path。
 `mode = "forward_pre_race_oz_v1"` は `OZ` basis-odds だけを使う既存 path。
 `mode = "forward_pre_race_tyb_oz_v1"` は `TYB` の current horse-level market と `OZ` の `place_basis_odds` を join する sanctioned mainline live path。
+`mode = "forward_collection_tyb_oz_v1"` は prospective window 専用。TYB/OZ を contract snapshot へ変換して Phase660 monitor を実行し、prediction / decision / reconciliation は起動しない。
 
 ## CLI
 

--- a/src/horse_bet_lab/jrdb_ingestion/handoff.py
+++ b/src/horse_bet_lab/jrdb_ingestion/handoff.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import date
 from pathlib import Path
 
 from horse_bet_lab.forward_test.raw_snapshot_intake import run_raw_snapshot_intake_precheck
@@ -21,6 +22,7 @@ from horse_bet_lab.jrdb_ingestion.oz_pre_race_adapter import (
     run_oz_pre_race_adapter,
 )
 from horse_bet_lab.jrdb_ingestion.trigger import (
+    HANDOFF_MODE_FORWARD_COLLECTION_TYB_OZ,
     HANDOFF_MODE_FORWARD_PRE_RACE_CONTRACT_LIKE,
     HANDOFF_MODE_FORWARD_PRE_RACE_OZ,
     HANDOFF_MODE_FORWARD_PRE_RACE_TYB_OZ,
@@ -32,6 +34,12 @@ from horse_bet_lab.jrdb_ingestion.tyb_oz_pre_race_adapter import (
     discover_tyb_source_paths,
     run_tyb_oz_pre_race_adapter,
 )
+from horse_bet_lab.research.prospective_collection_ops import (
+    ProspectiveCollectionOpsConfig,
+    run_prospective_collection_ops,
+)
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
 
 
 @dataclass(frozen=True)
@@ -40,6 +48,8 @@ class JRDBHandoffResult:
     ingest_summary: IngestionSummary | None
     pre_race_output_dir: Path | None
     unit_id: str | None
+    contract_snapshot_path: Path | None = None
+    collection_monitor_output_dir: Path | None = None
 
 
 def run_handoff(
@@ -60,6 +70,47 @@ def run_handoff(
             ingest_summary=ingest_summary,
             pre_race_output_dir=None,
             unit_id=None,
+        )
+    if trigger.handoff.mode == HANDOFF_MODE_FORWARD_COLLECTION_TYB_OZ:
+        collection = trigger.handoff.collection
+        if collection is None:
+            raise ValueError("forward collection handoff requires collection config")
+        observation_date = date.fromisoformat(collection.odds_observation_timestamp[:10])
+        result = run_prospective_collection_ops(
+            ProspectiveCollectionOpsConfig(
+                unit_id=collection.unit_id,
+                source_dir=raw_target_dir,
+                output_root=Path("data/forward_test/prospective_collection"),
+                input_source_name=collection.input_source_name,
+                input_source_url=collection.input_source_url,
+                input_source_timestamp=collection.input_source_timestamp,
+                odds_observation_timestamp=collection.odds_observation_timestamp,
+                carrier_identity=collection.carrier_identity,
+                as_of_date=observation_date,
+                repository_root=REPOSITORY_ROOT,
+                contract_path=(
+                    REPOSITORY_ROOT / "configs/phase658_2026_forward_preregistered_validation.json"
+                ),
+                checksum_path=(
+                    REPOSITORY_ROOT
+                    / "configs/phase658_2026_forward_preregistered_validation.sha256"
+                ),
+                superseded_contract_path=(
+                    REPOSITORY_ROOT / "configs/phase654_2026_forward_preregistered_validation.json"
+                ),
+                superseded_checksum_path=(
+                    REPOSITORY_ROOT
+                    / "configs/phase654_2026_forward_preregistered_validation.sha256"
+                ),
+            )
+        )
+        return JRDBHandoffResult(
+            raw_target_dir=raw_target_dir,
+            ingest_summary=ingest_summary,
+            pre_race_output_dir=None,
+            unit_id=result.unit_id,
+            contract_snapshot_path=result.contract_snapshot_path,
+            collection_monitor_output_dir=result.monitor_output_dir,
         )
     if trigger.handoff.mode not in {
         HANDOFF_MODE_FORWARD_PRE_RACE_CONTRACT_LIKE,
@@ -98,11 +149,15 @@ def _run_forward_pre_race_contract_like_handoff(
     scaffold_result = run_scaffold(
         PlaceForwardScaffoldConfig(
             unit_id=config.unit_id,
-            raw_input_path=Path(f"data/forward_test/runs/{config.unit_id}/raw/input_snapshot_raw.csv"),
+            raw_input_path=Path(
+                f"data/forward_test/runs/{config.unit_id}/raw/input_snapshot_raw.csv"
+            ),
             contract_output_path=Path(
                 f"data/forward_test/runs/{config.unit_id}/contract/input_snapshot_{config.unit_id}.csv"
             ),
-            pre_race_output_dir=Path(f"data/artifacts/place_forward_test/{config.unit_id}/pre_race"),
+            pre_race_output_dir=Path(
+                f"data/artifacts/place_forward_test/{config.unit_id}/pre_race"
+            ),
             reconciliation_output_dir=Path(
                 f"data/artifacts/place_forward_test/{config.unit_id}/reconciliation"
             ),
@@ -153,11 +208,15 @@ def _run_forward_pre_race_oz_handoff(
     scaffold_result = run_scaffold(
         PlaceForwardScaffoldConfig(
             unit_id=config.unit_id,
-            raw_input_path=Path(f"data/forward_test/runs/{config.unit_id}/raw/input_snapshot_raw.csv"),
+            raw_input_path=Path(
+                f"data/forward_test/runs/{config.unit_id}/raw/input_snapshot_raw.csv"
+            ),
             contract_output_path=Path(
                 f"data/forward_test/runs/{config.unit_id}/contract/input_snapshot_{config.unit_id}.csv"
             ),
-            pre_race_output_dir=Path(f"data/artifacts/place_forward_test/{config.unit_id}/pre_race"),
+            pre_race_output_dir=Path(
+                f"data/artifacts/place_forward_test/{config.unit_id}/pre_race"
+            ),
             reconciliation_output_dir=Path(
                 f"data/artifacts/place_forward_test/{config.unit_id}/reconciliation"
             ),
@@ -207,11 +266,15 @@ def _run_forward_pre_race_tyb_oz_handoff(
     scaffold_result = run_scaffold(
         PlaceForwardScaffoldConfig(
             unit_id=config.unit_id,
-            raw_input_path=Path(f"data/forward_test/runs/{config.unit_id}/raw/input_snapshot_raw.csv"),
+            raw_input_path=Path(
+                f"data/forward_test/runs/{config.unit_id}/raw/input_snapshot_raw.csv"
+            ),
             contract_output_path=Path(
                 f"data/forward_test/runs/{config.unit_id}/contract/input_snapshot_{config.unit_id}.csv"
             ),
-            pre_race_output_dir=Path(f"data/artifacts/place_forward_test/{config.unit_id}/pre_race"),
+            pre_race_output_dir=Path(
+                f"data/artifacts/place_forward_test/{config.unit_id}/pre_race"
+            ),
             reconciliation_output_dir=Path(
                 f"data/artifacts/place_forward_test/{config.unit_id}/reconciliation"
             ),

--- a/src/horse_bet_lab/jrdb_ingestion/orchestration.py
+++ b/src/horse_bet_lab/jrdb_ingestion/orchestration.py
@@ -57,9 +57,7 @@ def run_jrdb_auto_ingestion_job(
             dedupe_key=dedupe_key,
             ready_dir=Path(str(payload["ready_dir"])) if payload.get("ready_dir") else None,
             raw_target_dir=(
-                Path(str(payload["raw_target_dir"]))
-                if payload.get("raw_target_dir")
-                else None
+                Path(str(payload["raw_target_dir"])) if payload.get("raw_target_dir") else None
             ),
             report_path=processed_report_path,
         )
@@ -80,11 +78,14 @@ def run_jrdb_auto_ingestion_job(
             )
         )
         extracted_archives = tuple(
-            _record_extract(events, extracted=extract_archive(
-                archive.archive_path,
-                destination_dir=staging_extract_dir / archive.archive_name,
-                archive_kind=_lookup_archive_kind(trigger, archive.archive_name),
-            ))
+            _record_extract(
+                events,
+                extracted=extract_archive(
+                    archive.archive_path,
+                    destination_dir=staging_extract_dir / archive.archive_name,
+                    archive_kind=_lookup_archive_kind(trigger, archive.archive_name),
+                ),
+            )
             for archive in downloaded_archives
         )
 
@@ -106,6 +107,16 @@ def run_jrdb_auto_ingestion_job(
                 "pre_race_output_dir": (
                     str(handoff_result.pre_race_output_dir)
                     if handoff_result.pre_race_output_dir is not None
+                    else None
+                ),
+                "contract_snapshot_path": (
+                    str(handoff_result.contract_snapshot_path)
+                    if handoff_result.contract_snapshot_path is not None
+                    else None
+                ),
+                "collection_monitor_output_dir": (
+                    str(handoff_result.collection_monitor_output_dir)
+                    if handoff_result.collection_monitor_output_dir is not None
                     else None
                 ),
             }
@@ -235,6 +246,16 @@ def build_report_payload(
                 "pre_race_output_dir": (
                     str(handoff_result.pre_race_output_dir)
                     if handoff_result.pre_race_output_dir is not None
+                    else None
+                ),
+                "contract_snapshot_path": (
+                    str(handoff_result.contract_snapshot_path)
+                    if handoff_result.contract_snapshot_path is not None
+                    else None
+                ),
+                "collection_monitor_output_dir": (
+                    str(handoff_result.collection_monitor_output_dir)
+                    if handoff_result.collection_monitor_output_dir is not None
                     else None
                 ),
                 "ingested_file_count": (

--- a/src/horse_bet_lab/jrdb_ingestion/trigger.py
+++ b/src/horse_bet_lab/jrdb_ingestion/trigger.py
@@ -9,12 +9,14 @@ HANDOFF_MODE_NONE = "none"
 HANDOFF_MODE_FORWARD_PRE_RACE_CONTRACT_LIKE = "forward_pre_race_contract_like_csv_v1"
 HANDOFF_MODE_FORWARD_PRE_RACE_OZ = "forward_pre_race_oz_v1"
 HANDOFF_MODE_FORWARD_PRE_RACE_TYB_OZ = "forward_pre_race_tyb_oz_v1"
+HANDOFF_MODE_FORWARD_COLLECTION_TYB_OZ = "forward_collection_tyb_oz_v1"
 SUPPORTED_HANDOFF_MODES = frozenset(
     {
         HANDOFF_MODE_NONE,
         HANDOFF_MODE_FORWARD_PRE_RACE_CONTRACT_LIKE,
         HANDOFF_MODE_FORWARD_PRE_RACE_OZ,
         HANDOFF_MODE_FORWARD_PRE_RACE_TYB_OZ,
+        HANDOFF_MODE_FORWARD_COLLECTION_TYB_OZ,
     }
 )
 
@@ -43,11 +45,22 @@ class JRDBForwardPreRaceHandoffConfig:
 
 
 @dataclass(frozen=True)
+class JRDBForwardCollectionHandoffConfig:
+    unit_id: str
+    input_source_name: str
+    input_source_url: str
+    input_source_timestamp: str
+    odds_observation_timestamp: str
+    carrier_identity: str
+
+
+@dataclass(frozen=True)
 class JRDBHandoffConfig:
     mode: str
     ingest_ready_files: bool
     duckdb_path: Path | None = None
     pre_race: JRDBForwardPreRaceHandoffConfig | None = None
+    collection: JRDBForwardCollectionHandoffConfig | None = None
 
 
 @dataclass(frozen=True)
@@ -60,8 +73,7 @@ class JRDBAutoIngestionTrigger:
 
 
 class EmailTriggerWatcher(Protocol):
-    def poll(self) -> tuple[JRDBAutoIngestionTrigger, ...]:
-        ...
+    def poll(self) -> tuple[JRDBAutoIngestionTrigger, ...]: ...
 
 
 @dataclass(frozen=True)
@@ -125,6 +137,20 @@ def load_trigger_manifest(path: Path) -> JRDBAutoIngestionTrigger:
         if pre_race_payload is not None
         else None
     )
+    collection = (
+        JRDBForwardCollectionHandoffConfig(
+            unit_id=str(handoff_payload["unit_id"]),
+            input_source_name=str(handoff_payload["input_source_name"]),
+            input_source_url=str(handoff_payload["input_source_url"]),
+            input_source_timestamp=str(handoff_payload["input_source_timestamp"]),
+            odds_observation_timestamp=str(handoff_payload["odds_observation_timestamp"]),
+            carrier_identity=str(
+                handoff_payload.get("carrier_identity", "place_forward_live_snapshot_v1")
+            ),
+        )
+        if mode == HANDOFF_MODE_FORWARD_COLLECTION_TYB_OZ
+        else None
+    )
     duckdb_path = (
         Path(str(handoff_payload["duckdb_path"]))
         if handoff_payload.get("duckdb_path") is not None
@@ -138,9 +164,15 @@ def load_trigger_manifest(path: Path) -> JRDBAutoIngestionTrigger:
         archives=archives,
         handoff=JRDBHandoffConfig(
             mode=mode,
-            ingest_ready_files=bool(handoff_payload.get("ingest_ready_files", True)),
+            ingest_ready_files=bool(
+                handoff_payload.get(
+                    "ingest_ready_files",
+                    mode != HANDOFF_MODE_FORWARD_COLLECTION_TYB_OZ,
+                )
+            ),
             duckdb_path=duckdb_path,
             pre_race=pre_race,
+            collection=collection,
         ),
     )
 

--- a/tests/test_jrdb_prospective_collection_handoff.py
+++ b/tests/test_jrdb_prospective_collection_handoff.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import zipfile
+from pathlib import Path
+
+from horse_bet_lab.jrdb_ingestion.orchestration import run_jrdb_auto_ingestion_job
+from horse_bet_lab.jrdb_ingestion.trigger import (
+    HANDOFF_MODE_FORWARD_COLLECTION_TYB_OZ,
+    load_trigger_manifest,
+)
+from horse_bet_lab.research.prospective_collection_monitor import MONITOR_OK
+
+
+def test_auto_ingestion_collection_mode_stops_after_contract_monitor(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    archive_path = tmp_path / "fixture_tyb_oz.zip"
+    race_key = "06261101"
+    tyb_content = b"\r\n".join(
+        _make_tyb_line(
+            race_key=race_key,
+            horse_number=horse_number,
+            win_odds=2.0 + horse_number,
+            place_odds_low=1.0 + horse_number / 10,
+        )
+        for horse_number in range(1, 9)
+    )
+    oz_content = _make_oz_line(
+        race_key=race_key,
+        headcount=8,
+        win_basis_odds=tuple(2.2 + number for number in range(1, 9)),
+        place_basis_odds=tuple(1.1 + number / 10 for number in range(1, 9)),
+    )
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("nested/TYB260720.txt", tyb_content + b"\r\n")
+        archive.writestr("nested/OZ260720.txt", oz_content + b"\r\n")
+
+    manifest_path = tmp_path / "trigger.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "trigger_kind": "manual_fixture",
+                "message_id": "phase662-synthetic-collection",
+                "detected_at": "2026-07-20T15:20:00+09:00",
+                "archives": [
+                    {
+                        "name": archive_path.name,
+                        "source_uri": str(archive_path),
+                        "expected_sha256": hashlib.sha256(archive_path.read_bytes()).hexdigest(),
+                        "archive_kind": "zip",
+                    }
+                ],
+                "handoff": {
+                    "mode": HANDOFF_MODE_FORWARD_COLLECTION_TYB_OZ,
+                    "unit_id": "20260720_synthetic_auto_collection",
+                    "input_source_name": "jrdb_tyb_oz_official",
+                    "input_source_url": "https://example.invalid/jrdb/tyb-oz",
+                    "input_source_timestamp": "2026-07-20T15:19:00+09:00",
+                    "odds_observation_timestamp": "2026-07-20T15:20:00+09:00",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    trigger = load_trigger_manifest(manifest_path)
+    assert trigger.handoff.collection is not None
+    assert trigger.handoff.pre_race is None
+    assert trigger.handoff.duckdb_path is None
+    assert trigger.handoff.ingest_ready_files is False
+
+    result = run_jrdb_auto_ingestion_job(
+        trigger,
+        workspace_root=tmp_path / "workspace",
+        raw_dir=tmp_path / "raw",
+    )
+
+    assert result.status == "completed"
+    report = json.loads(result.report_path.read_text(encoding="utf-8"))
+    handoff_summary = report["handoff_summary"]
+    assert handoff_summary["pre_race_output_dir"] is None
+    contract_path = Path(handoff_summary["contract_snapshot_path"])
+    monitor_dir = Path(handoff_summary["collection_monitor_output_dir"])
+    assert contract_path.is_file()
+    monitor_summary = json.loads((monitor_dir / "phase660_summary.json").read_text())
+    assert monitor_summary["final_verdict"] == MONITOR_OK
+    assert not (tmp_path / "data/artifacts/place_forward_test").exists()
+
+
+def _make_tyb_line(
+    *,
+    race_key: str,
+    horse_number: int,
+    win_odds: float,
+    place_odds_low: float,
+) -> bytes:
+    chunks = [
+        race_key[:8].ljust(8),
+        f"{horse_number:02d}",
+        f"{0.0:>5.1f}" * 3,
+        f"{horse_number / 10:>5.1f}",
+        f"{0.0:>5.1f}" * 3,
+        "000",
+        "00000",
+        "ﾃｽﾄｼﾞｮｷ".ljust(12),
+        "540",
+        "0",
+        "10",
+        "2",
+        f"{win_odds:>6.1f}",
+        f"{place_odds_low:>6.1f}",
+        "1520",
+        "484",
+        "- 6",
+        "   ",
+        "2",
+        "7",
+        "1538",
+        " " * 23,
+    ]
+    return "".join(chunks).encode("cp932")
+
+
+def _make_oz_line(
+    *,
+    race_key: str,
+    headcount: int,
+    win_basis_odds: tuple[float, ...],
+    place_basis_odds: tuple[float, ...],
+) -> bytes:
+    win_text = "".join(f"{value:>5.1f}" for value in win_basis_odds)
+    place_text = "".join(f"{value:>5.1f}" for value in place_basis_odds)
+    return f"{race_key[:8].ljust(8)}{headcount:02d}{win_text}{' ' * 12}{place_text}".encode("ascii")


### PR DESCRIPTION
## Summary

- add `forward_collection_tyb_oz_v1` to the existing JRDB auto-ingestion handoff modes
- default this collection-only mode to no DuckDB ingest and require no model dataset or model version
- connect downloaded/extracted TYB/OZ archives to Phase661 and expose contract/monitor paths in job reports
- preserve all older pre-race handoff modes unchanged

## Validation

- `ruff check`: passed
- strict `mypy`: passed
- `compileall`: passed
- focused ingestion/collection tests: `16 passed`
- related Phase654-662 regression tests: `66 passed`
- synthetic archive end-to-end: download/copy, extract, contract snapshot, Phase660 monitor all passed

## Boundary

- the new mode did not create the legacy pre-race prediction artifact directory
- no real 2026 source rows, outcomes, model metrics, ROI, or betting artifacts were inspected
- actual archive availability and local JRDB authentication remain external prerequisites
- the original dirty worktree was not modified
