### PR TITLE
Phase663: harden JRDB authentication setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ data/raw/jrdb/*
 !data/raw/jrdb/.gitkeep
 data/local/*
 !data/local/.gitkeep
+.local/
 data/staging/*
 !data/staging/.gitkeep
 data/artifacts/*

--- a/configs/jrdb_auto_ingestion_auth.example
+++ b/configs/jrdb_auto_ingestion_auth.example
@@ -1,0 +1,5 @@
+# Copy this file to .local/jrdb_auto_ingestion_auth.toml.
+# Replace both placeholders, then run:
+# chmod 600 .local/jrdb_auto_ingestion_auth.toml
+username=replace_with_jrdb_username
+password=replace_with_jrdb_password

--- a/docs/runbooks/jrdb_auto_ingestion_mvp.md
+++ b/docs/runbooks/jrdb_auto_ingestion_mvp.md
@@ -28,6 +28,7 @@
    - `JRDB_AUTO_INGESTION_PASSWORD`
 2. local auth config
    - 例: `.local/jrdb_auto_ingestion_auth.toml`
+   - `configs/jrdb_auto_ingestion_auth.example` をコピーし、必ず `chmod 600` にする
 
 repo には入れない。
 

--- a/scripts/phase663_jrdb_auth_preflight.py
+++ b/scripts/phase663_jrdb_auth_preflight.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+from horse_bet_lab.jrdb_ingestion.downloader import (
+    DEFAULT_PASSWORD_ENV,
+    DEFAULT_USERNAME_ENV,
+    load_download_auth,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check JRDB authentication without printing secrets."
+    )
+    parser.add_argument(
+        "--auth-config",
+        type=Path,
+        default=Path(".local/jrdb_auto_ingestion_auth.toml"),
+    )
+    args = parser.parse_args()
+    username_present = bool(os.environ.get(DEFAULT_USERNAME_ENV))
+    password_present = bool(os.environ.get(DEFAULT_PASSWORD_ENV))
+    try:
+        auth = load_download_auth(auth_config_path=args.auth_config)
+    except (FileNotFoundError, PermissionError, ValueError) as exc:
+        print(json.dumps({"status": "blocked", "reason": str(exc)}, indent=2))
+        return 1
+    if auth is None:
+        print(json.dumps({"status": "blocked", "reason": "credentials are missing"}, indent=2))
+        return 1
+    source = "environment" if username_present and password_present else "local_config"
+    print(
+        json.dumps(
+            {
+                "status": "ready",
+                "source": source,
+                "username_present": True,
+                "password_present": True,
+                "secret_values_printed": False,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/horse_bet_lab/jrdb_ingestion/downloader.py
+++ b/src/horse_bet_lab/jrdb_ingestion/downloader.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import base64
 import hashlib
 import os
+import stat
 from dataclasses import dataclass
 from pathlib import Path
+from typing import BinaryIO
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
@@ -43,6 +45,12 @@ def load_download_auth(
         return None
     if not auth_config_path.exists():
         raise FileNotFoundError(f"JRDB auth config does not exist: {auth_config_path}")
+    mode = stat.S_IMODE(auth_config_path.stat().st_mode)
+    if mode & 0o077:
+        raise PermissionError(
+            "JRDB auth config must not be readable or writable by group/others; "
+            f"run chmod 600 {auth_config_path}"
+        )
 
     payload = {
         key.strip(): value.strip()
@@ -123,7 +131,7 @@ def _copy_source_to_file(
         return _stream_copy(response, destination_path)
 
 
-def _stream_copy(readable, destination_path: Path) -> tuple[int, str]:
+def _stream_copy(readable: BinaryIO, destination_path: Path) -> tuple[int, str]:
     digest = hashlib.sha256()
     total = 0
     with destination_path.open("wb") as file:

--- a/tests/test_jrdb_auth_safety.py
+++ b/tests/test_jrdb_auth_safety.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from horse_bet_lab.jrdb_ingestion.downloader import load_download_auth
+
+
+def test_auth_config_requires_private_permissions(tmp_path: Path) -> None:
+    path = tmp_path / "auth.toml"
+    path.write_text("username=test-user\npassword=test-password\n", encoding="utf-8")
+    path.chmod(0o644)
+
+    with pytest.raises(PermissionError, match="chmod 600"):
+        load_download_auth(auth_config_path=path)
+
+
+def test_auth_config_loads_without_printing_when_private(tmp_path: Path) -> None:
+    path = tmp_path / "auth.toml"
+    path.write_text("username=test-user\npassword=test-password\n", encoding="utf-8")
+    path.chmod(0o600)
+
+    auth = load_download_auth(auth_config_path=path)
+
+    assert auth is not None
+    assert auth.username == "test-user"
+    assert auth.password == "test-password"


### PR DESCRIPTION
## Summary

- ignore `.local/` so JRDB credentials cannot be accidentally committed
- provide a placeholder-only authentication example
- require local credential files to use private permissions (`chmod 600`)
- add a preflight command that reports readiness without printing secrets

## Validation

- Ruff: passed
- strict Mypy: passed
- compileall: passed
- authentication and ingestion tests: `8 passed`

No credentials or real archive data were used.
